### PR TITLE
fix: add shapeshift com subdomains to default cors

### DIFF
--- a/apps/notifications-service/src/main.ts
+++ b/apps/notifications-service/src/main.ts
@@ -6,7 +6,7 @@ async function bootstrap() {
   
   // Enable CORS
   app.enableCors({
-    origin: process.env.ALLOWED_ORIGINS?.split(',') || ['http://localhost:3000'],
+    origin: process.env.ALLOWED_ORIGINS?.split(',') || ['http://localhost:3000', '/\.shapeshift\.com$/'],
     credentials: true,
   });
 

--- a/apps/swap-service/src/main.ts
+++ b/apps/swap-service/src/main.ts
@@ -11,7 +11,7 @@ async function bootstrap() {
   
   // Enable CORS
   app.enableCors({
-    origin: process.env.ALLOWED_ORIGINS?.split(',') || ['http://localhost:3000'],
+    origin: process.env.ALLOWED_ORIGINS?.split(',') || ['http://localhost:3000', '/\.shapeshift\.com$/'],
     credentials: true,
   });
 

--- a/apps/user-service/src/main.ts
+++ b/apps/user-service/src/main.ts
@@ -6,7 +6,7 @@ async function bootstrap() {
   
   // Enable CORS
   app.enableCors({
-    origin: process.env.ALLOWED_ORIGINS?.split(',') || ['http://localhost:3000'],
+    origin: process.env.ALLOWED_ORIGINS?.split(',') || ['http://localhost:3000', '/\.shapeshift\.com$/'],
     credentials: true,
   });
 


### PR DESCRIPTION
We need to add our domains to default CORS or every requests not from localhost will fail and we don't want to add CORS to env variables every time we deploy