### PR TITLE
feat: add affiliate service with config storage and stats API

### DIFF
--- a/apps/swap-service/package.json
+++ b/apps/swap-service/package.json
@@ -22,6 +22,11 @@
     "axios": "^1.6.2",
     "class-transformer": "^0.5.1",
     "class-validator": "^0.14.3",
-    "prisma": "6.13.0"
+    "jsonwebtoken": "^9.0.3",
+    "prisma": "6.13.0",
+    "siwe": "^3.0.0"
+  },
+  "devDependencies": {
+    "@types/jsonwebtoken": "^9.0.10"
   }
 }

--- a/apps/swap-service/prisma/schema.prisma
+++ b/apps/swap-service/prisma/schema.prisma
@@ -7,6 +7,20 @@ datasource db {
   url      = env("DATABASE_URL")
 }
 
+model Affiliate {
+  id            String   @id @default(cuid())
+  walletAddress String   @unique @map("wallet_address")
+  partnerCode   String?  @unique @map("partner_code")
+  bps           Int      @default(60)
+  isActive      Boolean  @default(true) @map("is_active")
+  createdAt     DateTime @default(now()) @map("created_at")
+  updatedAt     DateTime @updatedAt @map("updated_at")
+
+  @@map("affiliates")
+  @@index([partnerCode])
+  @@index([isActive])
+}
+
 model Swap {
   id                               String         @id @default(cuid())
   swapId                           String         @unique

--- a/apps/swap-service/prisma/schema.prisma
+++ b/apps/swap-service/prisma/schema.prisma
@@ -8,13 +8,14 @@ datasource db {
 }
 
 model Affiliate {
-  id            String   @id @default(cuid())
-  walletAddress String   @unique @map("wallet_address")
-  partnerCode   String?  @unique @map("partner_code")
-  bps           Int      @default(60)
-  isActive      Boolean  @default(true) @map("is_active")
-  createdAt     DateTime @default(now()) @map("created_at")
-  updatedAt     DateTime @updatedAt @map("updated_at")
+  id             String   @id @default(cuid())
+  walletAddress  String   @unique @map("wallet_address")
+  receiveAddress String?  @map("receive_address")
+  partnerCode    String?  @unique @map("partner_code")
+  bps            Int      @default(60)
+  isActive       Boolean  @default(true) @map("is_active")
+  createdAt      DateTime @default(now()) @map("created_at")
+  updatedAt      DateTime @updatedAt @map("updated_at")
 
   @@map("affiliates")
   @@index([partnerCode])

--- a/apps/swap-service/src/affiliate/affiliate.controller.ts
+++ b/apps/swap-service/src/affiliate/affiliate.controller.ts
@@ -1,0 +1,195 @@
+import {
+  Controller,
+  Get,
+  Post,
+  Patch,
+  Param,
+  Body,
+  Query,
+  NotFoundException,
+  BadRequestException,
+  ConflictException,
+} from '@nestjs/common';
+import {
+  AffiliateService,
+  CreateAffiliateDto,
+  UpdateAffiliateDto,
+} from './affiliate.service';
+
+@Controller('v1/affiliate')
+export class AffiliateController {
+  constructor(private affiliateService: AffiliateService) {}
+
+  /**
+   * GET /v1/affiliate/stats
+   * Get affiliate stats (for dashboard)
+   */
+  @Get('stats')
+  async getStats(
+    @Query('address') address: string,
+    @Query('startDate') startDate?: string,
+    @Query('endDate') endDate?: string,
+  ) {
+    if (!address) {
+      throw new BadRequestException('address query parameter is required');
+    }
+
+    const start = startDate ? new Date(startDate) : undefined;
+    const end = endDate ? new Date(endDate) : undefined;
+
+    return this.affiliateService.getAffiliateStats(address, start, end);
+  }
+
+  /**
+   * GET /v1/affiliate/:address
+   * Get affiliate configuration
+   */
+  @Get(':address')
+  async getAffiliate(@Param('address') address: string) {
+    const affiliate = await this.affiliateService.getAffiliate(address);
+
+    if (!affiliate) {
+      throw new NotFoundException('Affiliate not found');
+    }
+
+    return affiliate;
+  }
+
+  /**
+   * POST /v1/affiliate
+   * Register as affiliate
+   * Note: In production, this should require SIWE authentication
+   */
+  @Post()
+  async createAffiliate(@Body() data: CreateAffiliateDto) {
+    // Validate wallet address
+    if (!data.walletAddress || !/^0x[a-fA-F0-9]{40}$/.test(data.walletAddress)) {
+      throw new BadRequestException('Invalid wallet address');
+    }
+
+    // Validate BPS range
+    if (data.bps !== undefined && (data.bps < 0 || data.bps > 1000)) {
+      throw new BadRequestException('BPS must be between 0 and 1000');
+    }
+
+    // Validate partner code format
+    if (
+      data.partnerCode &&
+      !/^[a-zA-Z0-9-]{3,32}$/.test(data.partnerCode)
+    ) {
+      throw new BadRequestException(
+        'Partner code must be 3-32 alphanumeric characters or hyphens',
+      );
+    }
+
+    try {
+      return await this.affiliateService.createAffiliate(data);
+    } catch (error) {
+      if (error instanceof Error) {
+        if (error.message.includes('already')) {
+          throw new ConflictException(error.message);
+        }
+      }
+      throw error;
+    }
+  }
+
+  /**
+   * PATCH /v1/affiliate/:address
+   * Update affiliate settings
+   * Note: In production, this should require SIWE authentication matching address
+   */
+  @Patch(':address')
+  async updateAffiliate(
+    @Param('address') address: string,
+    @Body() data: UpdateAffiliateDto,
+  ) {
+    // Validate BPS range
+    if (data.bps !== undefined && (data.bps < 0 || data.bps > 1000)) {
+      throw new BadRequestException('BPS must be between 0 and 1000');
+    }
+
+    try {
+      return await this.affiliateService.updateAffiliate(address, data);
+    } catch (error) {
+      if (error instanceof NotFoundException) {
+        throw error;
+      }
+      throw error;
+    }
+  }
+
+  /**
+   * POST /v1/affiliate/claim-code
+   * Claim a partner code
+   * Note: In production, this should require SIWE authentication
+   */
+  @Post('claim-code')
+  async claimPartnerCode(
+    @Body() data: { walletAddress: string; partnerCode: string },
+  ) {
+    if (!data.walletAddress || !data.partnerCode) {
+      throw new BadRequestException(
+        'walletAddress and partnerCode are required',
+      );
+    }
+
+    if (!/^0x[a-fA-F0-9]{40}$/.test(data.walletAddress)) {
+      throw new BadRequestException('Invalid wallet address');
+    }
+
+    try {
+      return await this.affiliateService.claimPartnerCode(
+        data.walletAddress,
+        data.partnerCode,
+      );
+    } catch (error) {
+      if (error instanceof Error) {
+        if (
+          error.message.includes('taken') ||
+          error.message.includes('reserved')
+        ) {
+          throw new ConflictException(error.message);
+        }
+        if (error.message.includes('must be')) {
+          throw new BadRequestException(error.message);
+        }
+      }
+      throw error;
+    }
+  }
+
+  /**
+   * GET /v1/affiliate/lookup/bps
+   * Lookup affiliate BPS by address (for public-api)
+   */
+  @Get('lookup/bps')
+  async lookupBps(@Query('address') address: string) {
+    if (!address) {
+      throw new BadRequestException('address query parameter is required');
+    }
+
+    const bps = await this.affiliateService.lookupAffiliateBps(address);
+    return { bps };
+  }
+}
+
+@Controller('v1/partner')
+export class PartnerController {
+  constructor(private affiliateService: AffiliateService) {}
+
+  /**
+   * GET /v1/partner/:code
+   * Resolve partner code to affiliate config
+   */
+  @Get(':code')
+  async resolvePartnerCode(@Param('code') code: string) {
+    const result = await this.affiliateService.resolvePartnerCode(code);
+
+    if (!result) {
+      throw new NotFoundException('Partner code not found');
+    }
+
+    return result;
+  }
+}

--- a/apps/swap-service/src/affiliate/affiliate.controller.ts
+++ b/apps/swap-service/src/affiliate/affiliate.controller.ts
@@ -6,15 +6,19 @@ import {
   Param,
   Body,
   Query,
+  Req,
+  UseGuards,
   NotFoundException,
   BadRequestException,
   ConflictException,
+  ForbiddenException,
 } from '@nestjs/common';
 import {
   AffiliateService,
   CreateAffiliateDto,
   UpdateAffiliateDto,
 } from './affiliate.service';
+import { SiweAuthGuard } from './siwe-auth.guard';
 
 @Controller('v1/affiliate')
 export class AffiliateController {
@@ -24,6 +28,30 @@ export class AffiliateController {
    * GET /v1/affiliate/stats
    * Get affiliate stats (for dashboard)
    */
+  @Get('swaps')
+  async getSwaps(
+    @Query('address') address: string,
+    @Query('startDate') startDate?: string,
+    @Query('endDate') endDate?: string,
+    @Query('limit') limit?: string,
+    @Query('offset') offset?: string,
+  ) {
+    if (!address) {
+      throw new BadRequestException('address query parameter is required');
+    }
+
+    const start = startDate ? new Date(startDate) : undefined;
+    const end = endDate ? new Date(endDate) : undefined;
+
+    return this.affiliateService.getAffiliateSwaps(
+      address,
+      start,
+      end,
+      limit ? parseInt(limit, 10) : 50,
+      offset ? parseInt(offset, 10) : 0,
+    );
+  }
+
   @Get('stats')
   async getStats(
     @Query('address') address: string,
@@ -55,24 +83,21 @@ export class AffiliateController {
     return affiliate;
   }
 
-  /**
-   * POST /v1/affiliate
-   * Register as affiliate
-   * Note: In production, this should require SIWE authentication
-   */
+  @UseGuards(SiweAuthGuard)
   @Post()
-  async createAffiliate(@Body() data: CreateAffiliateDto) {
-    // Validate wallet address
+  async createAffiliate(@Req() req: any, @Body() data: CreateAffiliateDto) {
     if (!data.walletAddress || !/^0x[a-fA-F0-9]{40}$/.test(data.walletAddress)) {
       throw new BadRequestException('Invalid wallet address');
     }
 
-    // Validate BPS range
+    if (req.siweAddress !== data.walletAddress.toLowerCase()) {
+      throw new ForbiddenException('Authenticated address does not match walletAddress');
+    }
+
     if (data.bps !== undefined && (data.bps < 0 || data.bps > 1000)) {
       throw new BadRequestException('BPS must be between 0 and 1000');
     }
 
-    // Validate partner code format
     if (
       data.partnerCode &&
       !/^[a-zA-Z0-9-]{3,32}$/.test(data.partnerCode)
@@ -80,6 +105,10 @@ export class AffiliateController {
       throw new BadRequestException(
         'Partner code must be 3-32 alphanumeric characters or hyphens',
       );
+    }
+
+    if (data.receiveAddress && !/^0x[a-fA-F0-9]{40}$/.test(data.receiveAddress)) {
+      throw new BadRequestException('Invalid receive address');
     }
 
     try {
@@ -94,19 +123,23 @@ export class AffiliateController {
     }
   }
 
-  /**
-   * PATCH /v1/affiliate/:address
-   * Update affiliate settings
-   * Note: In production, this should require SIWE authentication matching address
-   */
+  @UseGuards(SiweAuthGuard)
   @Patch(':address')
   async updateAffiliate(
+    @Req() req: any,
     @Param('address') address: string,
     @Body() data: UpdateAffiliateDto,
   ) {
-    // Validate BPS range
+    if (req.siweAddress !== address.toLowerCase()) {
+      throw new ForbiddenException('Authenticated address does not match target address');
+    }
+
     if (data.bps !== undefined && (data.bps < 0 || data.bps > 1000)) {
       throw new BadRequestException('BPS must be between 0 and 1000');
+    }
+
+    if (data.receiveAddress && !/^0x[a-fA-F0-9]{40}$/.test(data.receiveAddress)) {
+      throw new BadRequestException('Invalid receive address');
     }
 
     try {
@@ -119,13 +152,10 @@ export class AffiliateController {
     }
   }
 
-  /**
-   * POST /v1/affiliate/claim-code
-   * Claim a partner code
-   * Note: In production, this should require SIWE authentication
-   */
+  @UseGuards(SiweAuthGuard)
   @Post('claim-code')
   async claimPartnerCode(
+    @Req() req: any,
     @Body() data: { walletAddress: string; partnerCode: string },
   ) {
     if (!data.walletAddress || !data.partnerCode) {
@@ -136,6 +166,10 @@ export class AffiliateController {
 
     if (!/^0x[a-fA-F0-9]{40}$/.test(data.walletAddress)) {
       throw new BadRequestException('Invalid wallet address');
+    }
+
+    if (req.siweAddress !== data.walletAddress.toLowerCase()) {
+      throw new ForbiddenException('Authenticated address does not match walletAddress');
     }
 
     try {

--- a/apps/swap-service/src/affiliate/affiliate.module.ts
+++ b/apps/swap-service/src/affiliate/affiliate.module.ts
@@ -1,0 +1,12 @@
+import { Module } from '@nestjs/common';
+import { AffiliateService } from './affiliate.service';
+import { AffiliateController, PartnerController } from './affiliate.controller';
+import { PrismaModule } from '../prisma/prisma.module';
+
+@Module({
+  imports: [PrismaModule],
+  controllers: [AffiliateController, PartnerController],
+  providers: [AffiliateService],
+  exports: [AffiliateService],
+})
+export class AffiliateModule {}

--- a/apps/swap-service/src/affiliate/affiliate.module.ts
+++ b/apps/swap-service/src/affiliate/affiliate.module.ts
@@ -1,12 +1,11 @@
 import { Module } from '@nestjs/common';
 import { AffiliateService } from './affiliate.service';
 import { AffiliateController, PartnerController } from './affiliate.controller';
-import { PrismaModule } from '../prisma/prisma.module';
+import { PrismaService } from '../prisma/prisma.service';
 
 @Module({
-  imports: [PrismaModule],
   controllers: [AffiliateController, PartnerController],
-  providers: [AffiliateService],
+  providers: [PrismaService, AffiliateService],
   exports: [AffiliateService],
 })
 export class AffiliateModule {}

--- a/apps/swap-service/src/affiliate/affiliate.service.ts
+++ b/apps/swap-service/src/affiliate/affiliate.service.ts
@@ -1,0 +1,237 @@
+import { Injectable, Logger, NotFoundException } from '@nestjs/common';
+import { PrismaService } from '../prisma/prisma.service';
+import { Prisma } from '@prisma/client';
+
+export interface AffiliateStatsResult {
+  totalSwaps: number;
+  totalVolumeUsd: string;
+  totalFeesEarnedUsd: string;
+}
+
+export interface CreateAffiliateDto {
+  walletAddress: string;
+  partnerCode?: string;
+  bps?: number;
+}
+
+export interface UpdateAffiliateDto {
+  bps?: number;
+  isActive?: boolean;
+}
+
+@Injectable()
+export class AffiliateService {
+  private readonly logger = new Logger(AffiliateService.name);
+
+  constructor(private prisma: PrismaService) {}
+
+  /**
+   * Get affiliate by wallet address
+   */
+  async getAffiliate(walletAddress: string) {
+    const normalizedAddress = walletAddress.toLowerCase();
+    const affiliate = await this.prisma.affiliate.findUnique({
+      where: { walletAddress: normalizedAddress },
+    });
+
+    if (!affiliate) {
+      return null;
+    }
+
+    return affiliate;
+  }
+
+  /**
+   * Get affiliate by partner code
+   */
+  async getAffiliateByPartnerCode(partnerCode: string) {
+    const normalizedCode = partnerCode.toLowerCase();
+    const affiliate = await this.prisma.affiliate.findUnique({
+      where: { partnerCode: normalizedCode },
+    });
+
+    if (!affiliate) {
+      return null;
+    }
+
+    return affiliate;
+  }
+
+  /**
+   * Create a new affiliate registration
+   */
+  async createAffiliate(data: CreateAffiliateDto) {
+    const normalizedAddress = data.walletAddress.toLowerCase();
+    const normalizedCode = data.partnerCode?.toLowerCase();
+
+    // Check if already exists
+    const existing = await this.prisma.affiliate.findUnique({
+      where: { walletAddress: normalizedAddress },
+    });
+
+    if (existing) {
+      throw new Error('Affiliate already registered');
+    }
+
+    // Check if partner code is taken
+    if (normalizedCode) {
+      const existingCode = await this.prisma.affiliate.findUnique({
+        where: { partnerCode: normalizedCode },
+      });
+      if (existingCode) {
+        throw new Error('Partner code already taken');
+      }
+    }
+
+    return this.prisma.affiliate.create({
+      data: {
+        walletAddress: normalizedAddress,
+        partnerCode: normalizedCode,
+        bps: data.bps ?? 60,
+      },
+    });
+  }
+
+  /**
+   * Update affiliate settings
+   */
+  async updateAffiliate(walletAddress: string, data: UpdateAffiliateDto) {
+    const normalizedAddress = walletAddress.toLowerCase();
+
+    const existing = await this.prisma.affiliate.findUnique({
+      where: { walletAddress: normalizedAddress },
+    });
+
+    if (!existing) {
+      throw new NotFoundException('Affiliate not found');
+    }
+
+    return this.prisma.affiliate.update({
+      where: { walletAddress: normalizedAddress },
+      data: {
+        bps: data.bps ?? existing.bps,
+        isActive: data.isActive ?? existing.isActive,
+      },
+    });
+  }
+
+  /**
+   * Claim a partner code for an affiliate
+   */
+  async claimPartnerCode(walletAddress: string, partnerCode: string) {
+    const normalizedAddress = walletAddress.toLowerCase();
+    const normalizedCode = partnerCode.toLowerCase();
+
+    // Validate code format
+    if (!/^[a-z0-9-]{3,32}$/.test(normalizedCode)) {
+      throw new Error(
+        'Partner code must be 3-32 alphanumeric characters or hyphens',
+      );
+    }
+
+    // Check reserved codes
+    const reserved = ['shapeshift', 'ss', 'admin', 'api', 'test', 'demo'];
+    if (reserved.includes(normalizedCode)) {
+      throw new Error('This partner code is reserved');
+    }
+
+    // Check if code is taken
+    const existingCode = await this.prisma.affiliate.findUnique({
+      where: { partnerCode: normalizedCode },
+    });
+    if (existingCode && existingCode.walletAddress !== normalizedAddress) {
+      throw new Error('Partner code already taken');
+    }
+
+    // Update or create affiliate with code
+    return this.prisma.affiliate.upsert({
+      where: { walletAddress: normalizedAddress },
+      update: { partnerCode: normalizedCode },
+      create: {
+        walletAddress: normalizedAddress,
+        partnerCode: normalizedCode,
+        bps: 60,
+      },
+    });
+  }
+
+  /**
+   * Get affiliate stats - aggregated swap data
+   */
+  async getAffiliateStats(
+    affiliateAddress: string,
+    startDate?: Date,
+    endDate?: Date,
+  ): Promise<AffiliateStatsResult> {
+    const normalizedAddress = affiliateAddress.toLowerCase();
+
+    const whereClause: Prisma.SwapWhereInput = {
+      affiliateAddress: normalizedAddress,
+      status: 'SUCCESS',
+    };
+
+    if (startDate && endDate) {
+      whereClause.createdAt = {
+        gte: startDate,
+        lte: endDate,
+      };
+    }
+
+    // Get swap count
+    const totalSwaps = await this.prisma.swap.count({
+      where: whereClause,
+    });
+
+    // Get volume and fees
+    const swaps = await this.prisma.swap.findMany({
+      where: whereClause,
+      select: {
+        sellAmountUsd: true,
+        affiliateBps: true,
+      },
+    });
+
+    let totalVolumeUsd = 0;
+    let totalFeesEarnedUsd = 0;
+
+    for (const swap of swaps) {
+      const volumeUsd = parseFloat(swap.sellAmountUsd || '0');
+      const bps = parseInt(swap.affiliateBps || '0', 10);
+
+      totalVolumeUsd += volumeUsd;
+      // Fee = volume * (bps / 10000)
+      totalFeesEarnedUsd += volumeUsd * (bps / 10000);
+    }
+
+    return {
+      totalSwaps,
+      totalVolumeUsd: totalVolumeUsd.toFixed(2),
+      totalFeesEarnedUsd: totalFeesEarnedUsd.toFixed(2),
+    };
+  }
+
+  /**
+   * Resolve partner code to affiliate config
+   */
+  async resolvePartnerCode(partnerCode: string) {
+    const affiliate = await this.getAffiliateByPartnerCode(partnerCode);
+
+    if (!affiliate) {
+      return null;
+    }
+
+    return {
+      partnerCode: affiliate.partnerCode,
+      affiliateAddress: affiliate.walletAddress,
+      bps: affiliate.bps,
+    };
+  }
+
+  /**
+   * Lookup affiliate BPS - used by public-api to get correct BPS
+   */
+  async lookupAffiliateBps(affiliateAddress: string): Promise<number> {
+    const affiliate = await this.getAffiliate(affiliateAddress);
+    return affiliate?.bps ?? 60; // Default to 60 BPS if not registered
+  }
+}

--- a/apps/swap-service/src/affiliate/affiliate.service.ts
+++ b/apps/swap-service/src/affiliate/affiliate.service.ts
@@ -8,13 +8,38 @@ export interface AffiliateStatsResult {
   totalFeesEarnedUsd: string;
 }
 
+export interface AffiliateSwapItem {
+  swapId: string;
+  status: string;
+  sellAsset: unknown;
+  buyAsset: unknown;
+  sellAmountCryptoPrecision: string;
+  expectedBuyAmountCryptoPrecision: string;
+  actualBuyAmountCryptoPrecision: string | null;
+  sellAmountUsd: string | null;
+  affiliateBps: string | null;
+  affiliateFeeUsd: string | null;
+  swapperName: string;
+  sellTxHash: string | null;
+  createdAt: Date;
+}
+
+export interface AffiliateSwapsResult {
+  swaps: AffiliateSwapItem[];
+  total: number;
+  limit: number;
+  offset: number;
+}
+
 export interface CreateAffiliateDto {
   walletAddress: string;
+  receiveAddress?: string;
   partnerCode?: string;
   bps?: number;
 }
 
 export interface UpdateAffiliateDto {
+  receiveAddress?: string;
   bps?: number;
   isActive?: boolean;
 }
@@ -83,9 +108,12 @@ export class AffiliateService {
       }
     }
 
+    const normalizedReceiveAddress = data.receiveAddress?.toLowerCase();
+
     return this.prisma.affiliate.create({
       data: {
         walletAddress: normalizedAddress,
+        receiveAddress: normalizedReceiveAddress,
         partnerCode: normalizedCode,
         bps: data.bps ?? 60,
       },
@@ -106,12 +134,18 @@ export class AffiliateService {
       throw new NotFoundException('Affiliate not found');
     }
 
+    const updateData: Record<string, unknown> = {
+      bps: data.bps ?? existing.bps,
+      isActive: data.isActive ?? existing.isActive,
+    };
+
+    if (data.receiveAddress !== undefined) {
+      updateData.receiveAddress = data.receiveAddress.toLowerCase();
+    }
+
     return this.prisma.affiliate.update({
       where: { walletAddress: normalizedAddress },
-      data: {
-        bps: data.bps ?? existing.bps,
-        isActive: data.isActive ?? existing.isActive,
-      },
+      data: updateData,
     });
   }
 
@@ -130,7 +164,7 @@ export class AffiliateService {
     }
 
     // Check reserved codes
-    const reserved = ['shapeshift', 'ss', 'admin', 'api', 'test', 'demo'];
+    const reserved = ['ss', 'admin', 'api', 'test', 'demo'];
     if (reserved.includes(normalizedCode)) {
       throw new Error('This partner code is reserved');
     }
@@ -211,6 +245,66 @@ export class AffiliateService {
   }
 
   /**
+   * Get paginated list of swaps for an affiliate address
+   */
+  async getAffiliateSwaps(
+    affiliateAddress: string,
+    startDate?: Date,
+    endDate?: Date,
+    limit = 50,
+    offset = 0,
+  ): Promise<AffiliateSwapsResult> {
+    const normalizedAddress = affiliateAddress.toLowerCase();
+
+    const whereClause: Prisma.SwapWhereInput = {
+      affiliateAddress: normalizedAddress,
+    };
+
+    if (startDate && endDate) {
+      whereClause.createdAt = {
+        gte: startDate,
+        lte: endDate,
+      };
+    }
+
+    const [swaps, total] = await Promise.all([
+      this.prisma.swap.findMany({
+        where: whereClause,
+        orderBy: { createdAt: 'desc' },
+        take: limit,
+        skip: offset,
+        select: {
+          swapId: true,
+          status: true,
+          sellAsset: true,
+          buyAsset: true,
+          sellAmountCryptoPrecision: true,
+          expectedBuyAmountCryptoPrecision: true,
+          actualBuyAmountCryptoPrecision: true,
+          sellAmountUsd: true,
+          affiliateBps: true,
+          swapperName: true,
+          sellTxHash: true,
+          createdAt: true,
+        },
+      }),
+      this.prisma.swap.count({ where: whereClause }),
+    ]);
+
+    return {
+      swaps: swaps.map((swap) => ({
+        ...swap,
+        affiliateFeeUsd: swap.sellAmountUsd && swap.affiliateBps
+          ? (parseFloat(swap.sellAmountUsd) * parseInt(swap.affiliateBps, 10) / 10000).toFixed(2)
+          : null,
+      })),
+      total,
+      limit,
+      offset,
+    };
+  }
+
+  /**
    * Resolve partner code to affiliate config
    */
   async resolvePartnerCode(partnerCode: string) {
@@ -222,7 +316,7 @@ export class AffiliateService {
 
     return {
       partnerCode: affiliate.partnerCode,
-      affiliateAddress: affiliate.walletAddress,
+      affiliateAddress: affiliate.receiveAddress ?? affiliate.walletAddress,
       bps: affiliate.bps,
     };
   }

--- a/apps/swap-service/src/affiliate/index.ts
+++ b/apps/swap-service/src/affiliate/index.ts
@@ -1,0 +1,3 @@
+export * from './affiliate.service';
+export * from './affiliate.controller';
+export * from './affiliate.module';

--- a/apps/swap-service/src/affiliate/siwe-auth.controller.ts
+++ b/apps/swap-service/src/affiliate/siwe-auth.controller.ts
@@ -1,0 +1,73 @@
+import {
+  Controller,
+  Post,
+  Body,
+  BadRequestException,
+  UnauthorizedException,
+} from '@nestjs/common';
+import { SiweMessage } from 'siwe';
+import * as jwt from 'jsonwebtoken';
+import * as crypto from 'crypto';
+
+const JWT_SECRET = process.env.SIWE_JWT_SECRET || 'affiliate-siwe-secret-dev';
+const NONCE_EXPIRY_MS = 5 * 60 * 1000;
+
+const nonceStore = new Map<string, { createdAt: number }>();
+
+setInterval(() => {
+  const now = Date.now();
+  for (const [nonce, data] of nonceStore.entries()) {
+    if (now - data.createdAt > NONCE_EXPIRY_MS) {
+      nonceStore.delete(nonce);
+    }
+  }
+}, 60_000);
+
+@Controller('v1/auth/siwe')
+export class SiweAuthController {
+  @Post('nonce')
+  generateNonce(): { nonce: string } {
+    const nonce = crypto.randomBytes(16).toString('hex');
+    nonceStore.set(nonce, { createdAt: Date.now() });
+    return { nonce };
+  }
+
+  @Post('verify')
+  async verify(
+    @Body() body: { message: string; signature: string },
+  ): Promise<{ token: string; address: string }> {
+    if (!body.message || !body.signature) {
+      throw new BadRequestException('message and signature are required');
+    }
+
+    let siweMessage: SiweMessage;
+    try {
+      siweMessage = new SiweMessage(body.message);
+    } catch {
+      throw new BadRequestException('Invalid SIWE message format');
+    }
+
+    const nonceData = nonceStore.get(siweMessage.nonce);
+    if (!nonceData) {
+      throw new UnauthorizedException('Invalid or expired nonce');
+    }
+
+    if (Date.now() - nonceData.createdAt > NONCE_EXPIRY_MS) {
+      nonceStore.delete(siweMessage.nonce);
+      throw new UnauthorizedException('Nonce has expired');
+    }
+
+    try {
+      await siweMessage.verify({ signature: body.signature });
+    } catch {
+      throw new UnauthorizedException('Invalid signature');
+    }
+
+    nonceStore.delete(siweMessage.nonce);
+
+    const address = siweMessage.address.toLowerCase();
+    const token = jwt.sign({ address }, JWT_SECRET, { expiresIn: '24h' });
+
+    return { token, address };
+  }
+}

--- a/apps/swap-service/src/affiliate/siwe-auth.guard.ts
+++ b/apps/swap-service/src/affiliate/siwe-auth.guard.ts
@@ -1,0 +1,39 @@
+import {
+  Injectable,
+  CanActivate,
+  ExecutionContext,
+  UnauthorizedException,
+} from '@nestjs/common';
+import * as jwt from 'jsonwebtoken';
+
+const JWT_SECRET = process.env.SIWE_JWT_SECRET || 'affiliate-siwe-secret-dev';
+
+interface SiweJwtPayload {
+  address: string;
+  iat: number;
+  exp: number;
+}
+
+@Injectable()
+export class SiweAuthGuard implements CanActivate {
+  canActivate(context: ExecutionContext): boolean {
+    const request = context.switchToHttp().getRequest();
+    const authHeader = request.headers['authorization'];
+
+    if (!authHeader || !authHeader.startsWith('Bearer ')) {
+      throw new UnauthorizedException('Missing SIWE authentication token');
+    }
+
+    const token = authHeader.slice(7);
+
+    try {
+      const payload = jwt.verify(token, JWT_SECRET) as SiweJwtPayload;
+      request.siweAddress = payload.address.toLowerCase();
+      return true;
+    } catch {
+      throw new UnauthorizedException(
+        'Invalid or expired authentication token',
+      );
+    }
+  }
+}

--- a/apps/swap-service/src/app.module.ts
+++ b/apps/swap-service/src/app.module.ts
@@ -4,6 +4,8 @@ import { HttpModule } from '@nestjs/axios';
 import { PrismaService } from './prisma/prisma.service';
 import { SwapsController } from './swaps/swaps.controller';
 import { SwapsService } from './swaps/swaps.service';
+import { AffiliateController, PartnerController } from './affiliate/affiliate.controller';
+import { AffiliateService } from './affiliate/affiliate.service';
 import { SwapPollingService } from './polling/swap-polling.service';
 import { SwapVerificationService } from './verification/swap-verification.service';
 import { WebsocketGateway } from './websocket/websocket.gateway';
@@ -28,10 +30,11 @@ import { ConfigModule } from '@nestjs/config';
       envFilePath: ['.env', '../../.env'],
     }),
   ],
-  controllers: [SwapsController],
+  controllers: [SwapsController, AffiliateController, PartnerController],
   providers: [
     PrismaService,
     SwapsService,
+    AffiliateService,
     SwapPollingService,
     SwapVerificationService,
     WebsocketGateway,

--- a/apps/swap-service/src/app.module.ts
+++ b/apps/swap-service/src/app.module.ts
@@ -6,6 +6,7 @@ import { SwapsController } from './swaps/swaps.controller';
 import { SwapsService } from './swaps/swaps.service';
 import { AffiliateController, PartnerController } from './affiliate/affiliate.controller';
 import { AffiliateService } from './affiliate/affiliate.service';
+import { SiweAuthController } from './affiliate/siwe-auth.controller';
 import { SwapPollingService } from './polling/swap-polling.service';
 import { SwapVerificationService } from './verification/swap-verification.service';
 import { WebsocketGateway } from './websocket/websocket.gateway';
@@ -30,7 +31,7 @@ import { ConfigModule } from '@nestjs/config';
       envFilePath: ['.env', '../../.env'],
     }),
   ],
-  controllers: [SwapsController, AffiliateController, PartnerController],
+  controllers: [SwapsController, AffiliateController, PartnerController, SiweAuthController],
   providers: [
     PrismaService,
     SwapsService,

--- a/apps/swap-service/src/swaps/swaps.service.ts
+++ b/apps/swap-service/src/swaps/swaps.service.ts
@@ -105,11 +105,44 @@ export class SwapsService {
         );
       }
 
+      if (!sellAmountUsd && data.sellAmountUsd) {
+        sellAmountUsd = data.sellAmountUsd;
+      }
+
+      let affiliateAddress = data.affiliateAddress || null;
+      if (!affiliateAddress && data.partnerCode) {
+        try {
+          const affiliate = await this.prisma.affiliate.findFirst({
+            where: { partnerCode: data.partnerCode },
+            select: { receiveAddress: true, walletAddress: true },
+          });
+          if (affiliate) {
+            affiliateAddress =
+              affiliate.receiveAddress ?? affiliate.walletAddress;
+          }
+        } catch (error) {
+          this.logger.warn(
+            `Failed to resolve partner code ${data.partnerCode}:`,
+            error,
+          );
+        }
+      }
+
       const affiliateFeeAssetId = resolveAffiliateFeeAssetId(
         data.swapperName,
         data.sellAsset,
         data.buyAsset,
       );
+
+      const metadata = (data.metadata || {}) as Record<string, unknown>;
+      const relayMeta = (metadata.relayTransactionMetadata ??
+        (metadata.relayId ? { relayId: metadata.relayId } : undefined)) as
+        | Prisma.InputJsonValue
+        | undefined;
+      const chainflipId =
+        typeof metadata.chainflipSwapId === 'number'
+          ? (metadata.chainflipSwapId as number)
+          : undefined;
 
       const swap = await this.prisma.swap.create({
         data: {
@@ -136,10 +169,12 @@ export class SwapsService {
           userId: data.userId || 'api',
           referralCode,
           sellAmountUsd,
-          affiliateAddress: data.affiliateAddress || null,
+          affiliateAddress: affiliateAddress,
           affiliateBps: data.affiliateBps || null,
           origin: data.origin || null,
           affiliateFeeAssetId,
+          relayTransactionMetadata: relayMeta ?? undefined,
+          chainflipSwapId: chainflipId ?? undefined,
         },
       });
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,6 +28,9 @@ services:
     environment:
       - NODE_ENV=development
       - PORT=3002
+      - DATABASE_URL=postgresql://postgres:password@db:5432/microservices
+      - SWAP_SERVICE_URL=http://swap-service:3001
+      - NOTIFICATIONS_SERVICE_URL=http://notifications-service:3003
     depends_on:
       packages:
         condition: service_started
@@ -45,6 +48,9 @@ services:
     environment:
       - NODE_ENV=development
       - PORT=3001
+      - DATABASE_URL=postgresql://postgres:password@db:5432/microservices
+      - USER_SERVICE_URL=http://user-service:3002
+      - NOTIFICATIONS_SERVICE_URL=http://notifications-service:3003
     depends_on:
       packages:
         condition: service_started
@@ -62,6 +68,8 @@ services:
     environment:
       - NODE_ENV=development
       - PORT=3003
+      - DATABASE_URL=postgresql://postgres:password@db:5432/microservices
+      - USER_SERVICE_URL=http://user-service:3002
     depends_on:
       packages:
         condition: service_started

--- a/packages/shared-types/src/index.ts
+++ b/packages/shared-types/src/index.ts
@@ -82,7 +82,9 @@ export interface CreateSwapDto {
   metadata?: Record<string, any>;
   affiliateAddress?: string;
   affiliateBps?: string;
+  partnerCode?: string;
   origin?: 'web' | 'api' | 'widget';
+  sellAmountUsd?: string;
 }
 
 export interface UpdateSwapStatusDto {

--- a/yarn.lock
+++ b/yarn.lock
@@ -4232,7 +4232,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@noble/hashes@npm:1.8.0, @noble/hashes@npm:^1, @noble/hashes@npm:^1.0.0, @noble/hashes@npm:^1.2.0, @noble/hashes@npm:^1.3.1, @noble/hashes@npm:^1.4.0, @noble/hashes@npm:^1.5.0, @noble/hashes@npm:^1.7.1, @noble/hashes@npm:^1.8.0, @noble/hashes@npm:~1.8.0":
+"@noble/hashes@npm:1.8.0, @noble/hashes@npm:^1, @noble/hashes@npm:^1.0.0, @noble/hashes@npm:^1.1.2, @noble/hashes@npm:^1.2.0, @noble/hashes@npm:^1.3.1, @noble/hashes@npm:^1.4.0, @noble/hashes@npm:^1.5.0, @noble/hashes@npm:^1.7.1, @noble/hashes@npm:^1.8.0, @noble/hashes@npm:~1.8.0":
   version: 1.8.0
   resolution: "@noble/hashes@npm:1.8.0"
   checksum: 10/474b7f56bc6fb2d5b3a42132561e221b0ea4f91e590f4655312ca13667840896b34195e2b53b7f097ec080a1fdd3b58d902c2a8d0fbdf51d2e238b53808a177e
@@ -5236,10 +5236,13 @@ __metadata:
     "@prisma/client": "npm:6.13.0"
     "@shapeshift/shared-types": "workspace:*"
     "@shapeshift/shared-utils": "workspace:*"
+    "@types/jsonwebtoken": "npm:^9.0.10"
     axios: "npm:^1.6.2"
     class-transformer: "npm:^0.5.1"
     class-validator: "npm:^0.14.3"
+    jsonwebtoken: "npm:^9.0.3"
     prisma: "npm:6.13.0"
+    siwe: "npm:^3.0.0"
   languageName: unknown
   linkType: soft
 
@@ -6411,6 +6414,49 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@spruceid/siwe-parser@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "@spruceid/siwe-parser@npm:3.0.0"
+  dependencies:
+    "@noble/hashes": "npm:^1.1.2"
+    apg-js: "npm:^4.4.0"
+  checksum: 10/19239d4a18a953812e4a5cd25c51a9869b67643b00cf9b6f36091b0d7b8be09934d1ba41c7df60f6e05307ba5cbc7c4812c69b5d3de64a132ea08b80a35cb87f
+  languageName: node
+  linkType: hard
+
+"@stablelib/binary@npm:^1.0.1":
+  version: 1.0.1
+  resolution: "@stablelib/binary@npm:1.0.1"
+  dependencies:
+    "@stablelib/int": "npm:^1.0.1"
+  checksum: 10/c5ed769e2b5d607a5cdb72d325fcf98db437627862fade839daad934bd9ccf02a6f6e34f9de8cb3b18d72fce2ba6cc019a5d22398187d7d69d2607165f27f8bf
+  languageName: node
+  linkType: hard
+
+"@stablelib/int@npm:^1.0.1":
+  version: 1.0.1
+  resolution: "@stablelib/int@npm:1.0.1"
+  checksum: 10/65bfbf50a382eea70c68e05366bf379cfceff8fbc076f1c267ef2f2411d7aed64fd140c415cb6c29f19a3910d3b8b7805d4b32ad5721a5007a8e744a808c7ae3
+  languageName: node
+  linkType: hard
+
+"@stablelib/random@npm:^1.0.1":
+  version: 1.0.2
+  resolution: "@stablelib/random@npm:1.0.2"
+  dependencies:
+    "@stablelib/binary": "npm:^1.0.1"
+    "@stablelib/wipe": "npm:^1.0.1"
+  checksum: 10/f5ace0a588dc4c21f01cb85837892d4c872e994ae77a58a8eb7dd61aa0b26fb1e9b46b0445e71af57d963ef7d9f5965c64258fc0d04df7b2947bc48f2d3560c5
+  languageName: node
+  linkType: hard
+
+"@stablelib/wipe@npm:^1.0.1":
+  version: 1.0.1
+  resolution: "@stablelib/wipe@npm:1.0.1"
+  checksum: 10/287802eb146810a46ba72af70b82022caf83a8aeebde23605f5ee0decf64fe2b97a60c856e43b6617b5801287c30cfa863cfb0469e7fcde6f02d143cf0c6cbf4
+  languageName: node
+  linkType: hard
+
 "@standard-schema/spec@npm:^1.0.0":
   version: 1.0.0
   resolution: "@standard-schema/spec@npm:1.0.0"
@@ -6845,6 +6891,16 @@ __metadata:
   version: 7.0.15
   resolution: "@types/json-schema@npm:7.0.15"
   checksum: 10/1a3c3e06236e4c4aab89499c428d585527ce50c24fe8259e8b3926d3df4cfbbbcf306cfc73ddfb66cbafc973116efd15967020b0f738f63e09e64c7d260519e7
+  languageName: node
+  linkType: hard
+
+"@types/jsonwebtoken@npm:^9.0.10":
+  version: 9.0.10
+  resolution: "@types/jsonwebtoken@npm:9.0.10"
+  dependencies:
+    "@types/ms": "npm:*"
+    "@types/node": "npm:*"
+  checksum: 10/d7960d995ad815511c7f4e7f09d91522dfe16e7e800cdd6226c8b1b624c534e0f3b8f8f3beb60e3189865269f028002f1a490189beca5afd02bc96ef1d68f21f
   languageName: node
   linkType: hard
 
@@ -8026,6 +8082,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"apg-js@npm:^4.4.0":
+  version: 4.4.0
+  resolution: "apg-js@npm:4.4.0"
+  checksum: 10/425f19096026742f5f156f26542b68f55602aa60f0c4ae2d72a0a888cf15fe9622223191202262dd8979d76a6125de9d8fd164d56c95fb113f49099f405eb08c
+  languageName: node
+  linkType: hard
+
 "append-field@npm:^1.0.0":
   version: 1.0.0
   resolution: "append-field@npm:1.0.0"
@@ -8796,6 +8859,13 @@ __metadata:
   dependencies:
     node-int64: "npm:^0.4.0"
   checksum: 10/edba1b65bae682450be4117b695997972bd9a3c4dfee029cab5bcb72ae5393a79a8f909b8bc77957eb0deec1c7168670f18f4d5c556f46cdd3bca5f3b3a8d020
+  languageName: node
+  linkType: hard
+
+"buffer-equal-constant-time@npm:^1.0.1":
+  version: 1.0.1
+  resolution: "buffer-equal-constant-time@npm:1.0.1"
+  checksum: 10/80bb945f5d782a56f374b292770901065bad21420e34936ecbe949e57724b4a13874f735850dd1cc61f078773c4fb5493a41391e7bda40d1fa388d6bd80daaab
   languageName: node
   linkType: hard
 
@@ -9949,6 +10019,15 @@ __metadata:
   version: 0.2.0
   resolution: "eastasianwidth@npm:0.2.0"
   checksum: 10/9b1d3e1baefeaf7d70799db8774149cef33b97183a6addceeba0cf6b85ba23ee2686f302f14482006df32df75d32b17c509c143a3689627929e4a8efaf483952
+  languageName: node
+  linkType: hard
+
+"ecdsa-sig-formatter@npm:1.0.11":
+  version: 1.0.11
+  resolution: "ecdsa-sig-formatter@npm:1.0.11"
+  dependencies:
+    safe-buffer: "npm:^5.0.1"
+  checksum: 10/878e1aab8a42773320bc04c6de420bee21aebd71810e40b1799880a8a1c4594bcd6adc3d4213a0fb8147d4c3f529d8f9a618d7f59ad5a9a41b142058aceda23f
   languageName: node
   linkType: hard
 
@@ -13334,6 +13413,24 @@ __metadata:
   languageName: node
   linkType: hard
 
+"jsonwebtoken@npm:^9.0.3":
+  version: 9.0.3
+  resolution: "jsonwebtoken@npm:9.0.3"
+  dependencies:
+    jws: "npm:^4.0.1"
+    lodash.includes: "npm:^4.3.0"
+    lodash.isboolean: "npm:^3.0.3"
+    lodash.isinteger: "npm:^4.0.4"
+    lodash.isnumber: "npm:^3.0.3"
+    lodash.isplainobject: "npm:^4.0.6"
+    lodash.isstring: "npm:^4.0.1"
+    lodash.once: "npm:^4.0.0"
+    ms: "npm:^2.1.1"
+    semver: "npm:^7.5.4"
+  checksum: 10/a67a276db41fbfb458ebdc4938d5d7b01d4743e16bda0f25ac01996fe5b5819d66656153f6cfce19b4680b79ae9f9ca185965defc22e77e0abddf443573238d6
+  languageName: node
+  linkType: hard
+
 "jssha@npm:3.2.0":
   version: 3.2.0
   resolution: "jssha@npm:3.2.0"
@@ -13359,6 +13456,27 @@ __metadata:
   version: 6.0.2
   resolution: "just-diff@npm:6.0.2"
   checksum: 10/4c6b14d6be2a3391b020ea2b3d1a0acf2f4c60fcb16681c7f6f76d4c0f1841fae5b00c1a2e719980992e46320e4b6c55a4713683cb1873dd41a2621f08c9f8e8
+  languageName: node
+  linkType: hard
+
+"jwa@npm:^2.0.1":
+  version: 2.0.1
+  resolution: "jwa@npm:2.0.1"
+  dependencies:
+    buffer-equal-constant-time: "npm:^1.0.1"
+    ecdsa-sig-formatter: "npm:1.0.11"
+    safe-buffer: "npm:^5.0.1"
+  checksum: 10/b04312a1de85f912b96aa3a7211717b8336945fab5b4f7cbc7800f4c80934060c0a3111576fad8d76e41ad62887d6da4b21fd4c47e45c174197f8be7dc0c1694
+  languageName: node
+  linkType: hard
+
+"jws@npm:^4.0.1":
+  version: 4.0.1
+  resolution: "jws@npm:4.0.1"
+  dependencies:
+    jwa: "npm:^2.0.1"
+    safe-buffer: "npm:^5.0.1"
+  checksum: 10/75d7b157489fa9a72023712c58a7a7706c7e2b10eec27fabd3bb9cae0c9e492251ab72527d20a8a5f5726196f0508c320c643fddff7076657f6bca16d0ceeeeb
   languageName: node
   linkType: hard
 
@@ -13492,10 +13610,52 @@ __metadata:
   languageName: node
   linkType: hard
 
+"lodash.includes@npm:^4.3.0":
+  version: 4.3.0
+  resolution: "lodash.includes@npm:4.3.0"
+  checksum: 10/45e0a7c7838c931732cbfede6327da321b2b10482d5063ed21c020fa72b09ca3a4aa3bda4073906ab3f436cf36eb85a52ea3f08b7bab1e0baca8235b0e08fe51
+  languageName: node
+  linkType: hard
+
+"lodash.isboolean@npm:^3.0.3":
+  version: 3.0.3
+  resolution: "lodash.isboolean@npm:3.0.3"
+  checksum: 10/b70068b4a8b8837912b54052557b21fc4774174e3512ed3c5b94621e5aff5eb6c68089d0a386b7e801d679cd105d2e35417978a5e99071750aa2ed90bffd0250
+  languageName: node
+  linkType: hard
+
 "lodash.isequal@npm:^4.5.0":
   version: 4.5.0
   resolution: "lodash.isequal@npm:4.5.0"
   checksum: 10/82fc58a83a1555f8df34ca9a2cd300995ff94018ac12cc47c349655f0ae1d4d92ba346db4c19bbfc90510764e0c00ddcc985a358bdcd4b3b965abf8f2a48a214
+  languageName: node
+  linkType: hard
+
+"lodash.isinteger@npm:^4.0.4":
+  version: 4.0.4
+  resolution: "lodash.isinteger@npm:4.0.4"
+  checksum: 10/c971f5a2d67384f429892715550c67bac9f285604a0dd79275fd19fef7717aec7f2a6a33d60769686e436ceb9771fd95fe7fcb68ad030fc907d568d5a3b65f70
+  languageName: node
+  linkType: hard
+
+"lodash.isnumber@npm:^3.0.3":
+  version: 3.0.3
+  resolution: "lodash.isnumber@npm:3.0.3"
+  checksum: 10/913784275b565346255e6ae6a6e30b760a0da70abc29f3e1f409081585875105138cda4a429ff02577e1bc0a7ae2a90e0a3079a37f3a04c3d6c5aaa532f4cab2
+  languageName: node
+  linkType: hard
+
+"lodash.isplainobject@npm:^4.0.6":
+  version: 4.0.6
+  resolution: "lodash.isplainobject@npm:4.0.6"
+  checksum: 10/29c6351f281e0d9a1d58f1a4c8f4400924b4c79f18dfc4613624d7d54784df07efaff97c1ff2659f3e085ecf4fff493300adc4837553104cef2634110b0d5337
+  languageName: node
+  linkType: hard
+
+"lodash.isstring@npm:^4.0.1":
+  version: 4.0.1
+  resolution: "lodash.isstring@npm:4.0.1"
+  checksum: 10/eaac87ae9636848af08021083d796e2eea3d02e80082ab8a9955309569cb3a463ce97fd281d7dc119e402b2e7d8c54a23914b15d2fc7fff56461511dc8937ba0
   languageName: node
   linkType: hard
 
@@ -13510,6 +13670,13 @@ __metadata:
   version: 4.6.2
   resolution: "lodash.merge@npm:4.6.2"
   checksum: 10/d0ea2dd0097e6201be083865d50c3fb54fbfbdb247d9cc5950e086c991f448b7ab0cdab0d57eacccb43473d3f2acd21e134db39f22dac2d6c9ba6bf26978e3d6
+  languageName: node
+  linkType: hard
+
+"lodash.once@npm:^4.0.0":
+  version: 4.1.1
+  resolution: "lodash.once@npm:4.1.1"
+  checksum: 10/202f2c8c3d45e401b148a96de228e50ea6951ee5a9315ca5e15733d5a07a6b1a02d9da1e7fdf6950679e17e8ca8f7190ec33cae47beb249b0c50019d753f38f3
   languageName: node
   linkType: hard
 
@@ -14143,7 +14310,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ms@npm:^2.0.0, ms@npm:^2.1.3":
+"ms@npm:^2.0.0, ms@npm:^2.1.1, ms@npm:^2.1.3":
   version: 2.1.3
   resolution: "ms@npm:2.1.3"
   checksum: 10/aa92de608021b242401676e35cfa5aa42dd70cbdc082b916da7fb925c542173e36bce97ea3e804923fe92c0ad991434e4a38327e15a1b5b5f945d66df615ae6d
@@ -16560,6 +16727,18 @@ __metadata:
     "@sigstore/tuf": "npm:^2.3.4"
     "@sigstore/verify": "npm:^1.2.1"
   checksum: 10/4e0a82338d12370264dced2395cda18aaaad45fec630365ec88eaa1a4ba40f5eb08cd3b0c8688489d52e93f643b6598d682961f67858636f55300c590b1ddf62
+  languageName: node
+  linkType: hard
+
+"siwe@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "siwe@npm:3.0.0"
+  dependencies:
+    "@spruceid/siwe-parser": "npm:^3.0.0"
+    "@stablelib/random": "npm:^1.0.1"
+  peerDependencies:
+    ethers: ^5.6.8 || ^6.0.8
+  checksum: 10/9be89fe6163be6508c4a65594002a2841cc2ea5cbf3bdb25ca26a214ad08a7a7ad21915b1fe6dd23bdd2f02c61992e1b7676b24d70e1ae85e5cb0e832470c7cc
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary
Add affiliate management endpoints to swap-service for the affiliate system alignment.

## Changes
- **Prisma Schema**: Add `Affiliate` model for storing affiliate configurations (wallet address, partner code, BPS, active status)
- **AffiliateService**: Business logic for affiliate CRUD, partner codes, stats aggregation
- **AffiliateController**: REST endpoints for affiliate management
- **PartnerController**: Partner code resolution endpoint

## New Endpoints
| Method | Endpoint | Description |
|--------|----------|-------------|
| GET | `/v1/affiliate/stats` | Get affiliate swap stats (for dashboard) |
| GET | `/v1/affiliate/:address` | Get affiliate config |
| POST | `/v1/affiliate` | Register as affiliate |
| PATCH | `/v1/affiliate/:address` | Update affiliate settings |
| POST | `/v1/affiliate/claim-code` | Claim partner code |
| GET | `/v1/affiliate/lookup/bps` | Lookup BPS for public-api |
| GET | `/v1/partner/:code` | Resolve partner code to affiliate |

## Database Migration Required
```bash
npx prisma migrate dev --name add_affiliate_table
```

## Related
- Part of affiliate system alignment epic
- Closes beads: web-dhf, web-ms0, web-dew
- Related PR in shapeshift/web for public-api and dashboard updates