### PR TITLE
fix: update CORS to allow all localhost origins

### DIFF
--- a/apps/notifications-service/src/main.ts
+++ b/apps/notifications-service/src/main.ts
@@ -8,7 +8,7 @@ async function bootstrap() {
   // Enable CORS
   app.enableCors({
     origin: process.env.ALLOWED_ORIGINS?.split(',') || [
-      'http://localhost:3000',
+      /^http:\/\/(\w+\.)?localhost(:\d+)?$/,
       /\.shapeshift\.com$/,
     ],
     credentials: true,

--- a/apps/swap-service/src/main.ts
+++ b/apps/swap-service/src/main.ts
@@ -14,7 +14,7 @@ async function bootstrap() {
   // Enable CORS
   app.enableCors({
     origin: process.env.ALLOWED_ORIGINS?.split(',') || [
-      'http://localhost:3000',
+      /^http:\/\/(\w+\.)?localhost(:\d+)?$/,
       /\.shapeshift\.com$/,
     ],
     credentials: true,

--- a/apps/user-service/src/main.ts
+++ b/apps/user-service/src/main.ts
@@ -8,7 +8,7 @@ async function bootstrap() {
   // Enable CORS
   app.enableCors({
     origin: process.env.ALLOWED_ORIGINS?.split(',') || [
-      'http://localhost:3000',
+      /^http:\/\/(\w+\.)?localhost(:\d+)?$/,
       /\.shapeshift\.com$/,
     ],
     credentials: true,


### PR DESCRIPTION
## Summary
- Replaces hardcoded `http://localhost:3000` with regex `/^http:\/\/(\w+\.)?localhost(:\d+)?$/` across all three services
- Allows any localhost origin: `http://localhost`, `http://localhost:3000`, `http://web.localhost:1355`, etc.

## Test plan
- [ ] Verify requests from `http://localhost:<any port>` are accepted
- [ ] Verify requests from `http://<subdomain>.localhost:<port>` are accepted (e.g. proxy setups)
- [ ] Verify non-localhost origins are still blocked

🤖 Generated with [Claude Code](https://claude.com/claude-code)