### PR TITLE
chore: format and lint project for continued work

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,12 +24,14 @@ shapeshift-backend/
 ## Services
 
 ### User Service (`apps/user-service`)
+
 - **Port**: 3002
 - **Purpose**: Manages user accounts, devices, and authentication
 - **Database**: PostgreSQL
 - **API**: `/users/*`
 
 ### Swap Service (`apps/swap-service`)
+
 - **Port**: 3001
 - **Purpose**: Handles swaps and WebSocket connections
 - **Database**: PostgreSQL
@@ -38,6 +40,7 @@ shapeshift-backend/
 - **Dependencies**: User Service, Notifications Service
 
 ### Notifications Service (`apps/notifications-service`)
+
 - **Port**: 3003
 - **Purpose**: Manages notifications and push notifications
 - **Database**: PostgreSQL
@@ -65,6 +68,7 @@ shapeshift-backend/
 ## Getting Started
 
 ### Prerequisites
+
 - Node.js 22+
 - Yarn 4+
 - Docker (for containerized development)
@@ -75,6 +79,7 @@ shapeshift-backend/
    Ask the team for the EXPO token used to launch notifications.
 
 2. **Install dependencies**:
+
    ```bash
    yarn install
    ```
@@ -87,6 +92,7 @@ shapeshift-backend/
 ### Development
 
 #### Option 1: Docker Development (recommended)
+
 ```bash
 # Start all services
 docker-compose up -d
@@ -99,6 +105,7 @@ docker-compose logs -f swap-service db
 ```
 
 #### Option 2: Local Development
+
 ```bash
 yarn start:dev
 ```
@@ -106,6 +113,7 @@ yarn start:dev
 ### Available Scripts
 
 #### Root Level
+
 - `yarn build` - Build all packages and apps (runs `db:generate` first)
 - `yarn dev` - Start all services in development mode
 - `yarn test` - Run tests
@@ -126,12 +134,14 @@ All migrations are managed from the root using a shared Prisma schema at `prisma
 1. Update the relevant schema file in `prisma/schema/`
 
 2. Start a fresh local DB and apply existing migrations as baseline:
+
    ```bash
    docker-compose down -v && docker-compose up -d db
    DATABASE_URL="postgresql://postgres:password@localhost:5432/microservices" yarn db:migrate
    ```
 
 3. Generate the migration (creates the file without applying it):
+
    ```bash
    DATABASE_URL="postgresql://postgres:password@localhost:5432/microservices" yarn db:migrate:create <migration_name>
    ```
@@ -139,6 +149,7 @@ All migrations are managed from the root using a shared Prisma schema at `prisma
 4. Review the generated SQL in `prisma/migrations/<timestamp>_<name>/migration.sql`
 
 5. Apply and test locally:
+
    ```bash
    DATABASE_URL="postgresql://postgres:password@localhost:5432/microservices" yarn db:migrate
    ```
@@ -146,6 +157,7 @@ All migrations are managed from the root using a shared Prisma schema at `prisma
 6. Commit and open a PR — production migrations are applied automatically on deployment.
 
 ### Validating migration state against a database
+
 ```bash
 DATABASE_URL="postgresql://..." yarn db:migrate:status
 ```

--- a/apps/notifications-service/railway.json
+++ b/apps/notifications-service/railway.json
@@ -3,7 +3,12 @@
   "build": {
     "builder": "RAILPACK",
     "buildCommand": "yarn build",
-    "watchPatterns": ["yarn.lock", "apps/notifications-service/**", "packages/**", "prisma/**"]
+    "watchPatterns": [
+      "yarn.lock",
+      "apps/notifications-service/**",
+      "packages/**",
+      "prisma/**"
+    ]
   },
   "deploy": {
     "preDeployCommand": "yarn db:migrate",

--- a/apps/notifications-service/tsconfig.json
+++ b/apps/notifications-service/tsconfig.json
@@ -2,7 +2,7 @@
   "extends": "../../tsconfig.json",
   "compilerOptions": {
     "outDir": "dist",
-    "rootDir": "src",
+    "rootDir": "src"
   },
   "include": ["src/**/*"],
   "exclude": ["node_modules", "dist"]

--- a/apps/swap-service/railway.json
+++ b/apps/swap-service/railway.json
@@ -3,7 +3,12 @@
   "build": {
     "builder": "RAILPACK",
     "buildCommand": "yarn build",
-    "watchPatterns": ["yarn.lock", "apps/swap-service/**", "packages/**", "prisma/**"]
+    "watchPatterns": [
+      "yarn.lock",
+      "apps/swap-service/**",
+      "packages/**",
+      "prisma/**"
+    ]
   },
   "deploy": {
     "preDeployCommand": "yarn db:migrate",

--- a/apps/swap-service/src/affiliate/affiliate.controller.ts
+++ b/apps/swap-service/src/affiliate/affiliate.controller.ts
@@ -18,7 +18,7 @@ import {
   CreateAffiliateDto,
   UpdateAffiliateDto,
 } from './affiliate.service';
-import { SiweAuthGuard } from './siwe-auth.guard';
+import { SiweAuthGuard, SiweRequest } from './siwe-auth.guard';
 
 @Controller('v1/affiliate')
 export class AffiliateController {
@@ -85,29 +85,37 @@ export class AffiliateController {
 
   @UseGuards(SiweAuthGuard)
   @Post()
-  async createAffiliate(@Req() req: any, @Body() data: CreateAffiliateDto) {
-    if (!data.walletAddress || !/^0x[a-fA-F0-9]{40}$/.test(data.walletAddress)) {
+  async createAffiliate(
+    @Req() req: SiweRequest,
+    @Body() data: CreateAffiliateDto,
+  ) {
+    if (
+      !data.walletAddress ||
+      !/^0x[a-fA-F0-9]{40}$/.test(data.walletAddress)
+    ) {
       throw new BadRequestException('Invalid wallet address');
     }
 
     if (req.siweAddress !== data.walletAddress.toLowerCase()) {
-      throw new ForbiddenException('Authenticated address does not match walletAddress');
+      throw new ForbiddenException(
+        'Authenticated address does not match walletAddress',
+      );
     }
 
     if (data.bps !== undefined && (data.bps < 0 || data.bps > 1000)) {
       throw new BadRequestException('BPS must be between 0 and 1000');
     }
 
-    if (
-      data.partnerCode &&
-      !/^[a-zA-Z0-9-]{3,32}$/.test(data.partnerCode)
-    ) {
+    if (data.partnerCode && !/^[a-zA-Z0-9-]{3,32}$/.test(data.partnerCode)) {
       throw new BadRequestException(
         'Partner code must be 3-32 alphanumeric characters or hyphens',
       );
     }
 
-    if (data.receiveAddress && !/^0x[a-fA-F0-9]{40}$/.test(data.receiveAddress)) {
+    if (
+      data.receiveAddress &&
+      !/^0x[a-fA-F0-9]{40}$/.test(data.receiveAddress)
+    ) {
       throw new BadRequestException('Invalid receive address');
     }
 
@@ -126,19 +134,24 @@ export class AffiliateController {
   @UseGuards(SiweAuthGuard)
   @Patch(':address')
   async updateAffiliate(
-    @Req() req: any,
+    @Req() req: SiweRequest,
     @Param('address') address: string,
     @Body() data: UpdateAffiliateDto,
   ) {
     if (req.siweAddress !== address.toLowerCase()) {
-      throw new ForbiddenException('Authenticated address does not match target address');
+      throw new ForbiddenException(
+        'Authenticated address does not match target address',
+      );
     }
 
     if (data.bps !== undefined && (data.bps < 0 || data.bps > 1000)) {
       throw new BadRequestException('BPS must be between 0 and 1000');
     }
 
-    if (data.receiveAddress && !/^0x[a-fA-F0-9]{40}$/.test(data.receiveAddress)) {
+    if (
+      data.receiveAddress &&
+      !/^0x[a-fA-F0-9]{40}$/.test(data.receiveAddress)
+    ) {
       throw new BadRequestException('Invalid receive address');
     }
 
@@ -155,7 +168,7 @@ export class AffiliateController {
   @UseGuards(SiweAuthGuard)
   @Post('claim-code')
   async claimPartnerCode(
-    @Req() req: any,
+    @Req() req: SiweRequest,
     @Body() data: { walletAddress: string; partnerCode: string },
   ) {
     if (!data.walletAddress || !data.partnerCode) {
@@ -169,7 +182,9 @@ export class AffiliateController {
     }
 
     if (req.siweAddress !== data.walletAddress.toLowerCase()) {
-      throw new ForbiddenException('Authenticated address does not match walletAddress');
+      throw new ForbiddenException(
+        'Authenticated address does not match walletAddress',
+      );
     }
 
     try {

--- a/apps/swap-service/src/affiliate/affiliate.service.ts
+++ b/apps/swap-service/src/affiliate/affiliate.service.ts
@@ -294,9 +294,14 @@ export class AffiliateService {
     return {
       swaps: swaps.map((swap) => ({
         ...swap,
-        affiliateFeeUsd: swap.sellAmountUsd && swap.affiliateBps
-          ? (parseFloat(swap.sellAmountUsd) * parseInt(swap.affiliateBps, 10) / 10000).toFixed(2)
-          : null,
+        affiliateFeeUsd:
+          swap.sellAmountUsd && swap.affiliateBps
+            ? (
+                (parseFloat(swap.sellAmountUsd) *
+                  parseInt(swap.affiliateBps, 10)) /
+                10000
+              ).toFixed(2)
+            : null,
       })),
       total,
       limit,

--- a/apps/swap-service/src/affiliate/siwe-auth.guard.ts
+++ b/apps/swap-service/src/affiliate/siwe-auth.guard.ts
@@ -4,6 +4,7 @@ import {
   ExecutionContext,
   UnauthorizedException,
 } from '@nestjs/common';
+import type { Request } from 'express';
 import * as jwt from 'jsonwebtoken';
 
 const JWT_SECRET = process.env.SIWE_JWT_SECRET || 'affiliate-siwe-secret-dev';
@@ -14,10 +15,14 @@ interface SiweJwtPayload {
   exp: number;
 }
 
+export interface SiweRequest extends Request {
+  siweAddress: string;
+}
+
 @Injectable()
 export class SiweAuthGuard implements CanActivate {
   canActivate(context: ExecutionContext): boolean {
-    const request = context.switchToHttp().getRequest();
+    const request = context.switchToHttp().getRequest<SiweRequest>();
     const authHeader = request.headers['authorization'];
 
     if (!authHeader || !authHeader.startsWith('Bearer ')) {

--- a/apps/swap-service/src/app.module.ts
+++ b/apps/swap-service/src/app.module.ts
@@ -4,7 +4,10 @@ import { HttpModule } from '@nestjs/axios';
 import { PrismaService } from './prisma/prisma.service';
 import { SwapsController } from './swaps/swaps.controller';
 import { SwapsService } from './swaps/swaps.service';
-import { AffiliateController, PartnerController } from './affiliate/affiliate.controller';
+import {
+  AffiliateController,
+  PartnerController,
+} from './affiliate/affiliate.controller';
 import { AffiliateService } from './affiliate/affiliate.service';
 import { SiweAuthController } from './affiliate/siwe-auth.controller';
 import { SwapPollingService } from './polling/swap-polling.service';
@@ -31,7 +34,12 @@ import { ConfigModule } from '@nestjs/config';
       envFilePath: ['.env', '../../.env'],
     }),
   ],
-  controllers: [SwapsController, AffiliateController, PartnerController, SiweAuthController],
+  controllers: [
+    SwapsController,
+    AffiliateController,
+    PartnerController,
+    SiweAuthController,
+  ],
   providers: [
     PrismaService,
     SwapsService,

--- a/apps/swap-service/tsconfig.json
+++ b/apps/swap-service/tsconfig.json
@@ -2,7 +2,7 @@
   "extends": "../../tsconfig.json",
   "compilerOptions": {
     "outDir": "dist",
-    "rootDir": "src",
+    "rootDir": "src"
   },
   "include": ["src/**/*"],
   "exclude": ["node_modules", "dist"]

--- a/apps/user-service/railway.json
+++ b/apps/user-service/railway.json
@@ -3,7 +3,12 @@
   "build": {
     "builder": "RAILPACK",
     "buildCommand": "yarn build",
-    "watchPatterns": ["yarn.lock", "apps/user-service/**", "packages/**", "prisma/**"]
+    "watchPatterns": [
+      "yarn.lock",
+      "apps/user-service/**",
+      "packages/**",
+      "prisma/**"
+    ]
   },
   "deploy": {
     "preDeployCommand": "yarn db:migrate",

--- a/apps/user-service/tsconfig.json
+++ b/apps/user-service/tsconfig.json
@@ -2,7 +2,7 @@
   "extends": "../../tsconfig.json",
   "compilerOptions": {
     "outDir": "dist",
-    "rootDir": "src",
+    "rootDir": "src"
   },
   "include": ["src/**/*"],
   "exclude": ["node_modules", "dist"]

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "packages/*"
   ],
   "scripts": {
+    "clean": "turbo run clean && rm -rf node_modules",
     "build": "turbo run build",
     "dev": "turbo run dev",
     "start": "turbo run start",
@@ -30,7 +31,6 @@
     "db:migrate:status": "prisma migrate status",
     "db:migrate:create": "prisma migrate dev --create-only --name",
     "db:studio": "prisma studio",
-    "clean": "turbo run clean && rm -rf node_modules",
     "referral-rewards": "ts-node scripts/referral-rewards.ts"
   },
   "dependencies": {

--- a/scripts/REFERRAL_REWARDS_README.md
+++ b/scripts/REFERRAL_REWARDS_README.md
@@ -9,10 +9,12 @@ The referral rewards system tracks swap volume from referred users and distribut
 ### Database Schema
 
 **user-service:**
+
 - `ReferralCode`: Stores referral codes with owner addresses
 - `ReferralUsage`: Tracks which addresses have used referral codes (one code per address)
 
 **swap-service:**
+
 - `Swap.referralCode`: Optional field to track which code was used for a swap
 - `Swap.sellAmountUsd`: USD value at the time of the swap
 - `Swap.isReferralEligible`: Boolean to exclude certain swaps from rewards
@@ -21,6 +23,7 @@ The referral rewards system tracks swap volume from referred users and distribut
 
 **POST /referrals/codes**
 Create a new referral code
+
 ```json
 {
   "code": "SHAPESHIFTER",
@@ -32,6 +35,7 @@ Create a new referral code
 
 **POST /referrals/use**
 Apply a referral code to an address
+
 ```json
 {
   "code": "SHAPESHIFTER",
@@ -68,6 +72,7 @@ yarn referral-rewards stats dist_1234567890
 ### Calculation Formula
 
 For each referrer:
+
 ```
 foxReward = (referrerVolume / totalVolume) * totalFoxDistributed
 ```
@@ -75,17 +80,20 @@ foxReward = (referrerVolume / totalVolume) * totalFoxDistributed
 ### Output Files
 
 Distributions are saved to `distributions/` directory:
+
 - `dist_xxxxx_Distribution_Name.json`: Full distribution data
 - `dist_xxxxx_safe_batch.json`: Safe multisig transaction batch
 
 ### Safe Multisig Integration
 
 The script generates a JSON file compatible with Safe's batch transaction interface:
+
 1. Import the `*_safe_batch.json` file into Safe UI
 2. Review the transactions (one deposit per referrer)
 3. Sign and execute the multisig transaction
 
 Each transaction calls the RFOX staking contract's deposit function with:
+
 - User address (referrer's address)
 - Amount in FOX wei (calculated reward amount)
 
@@ -98,6 +106,7 @@ RFOX_STAKING_CONTRACT=0x... # RFOX staking contract address
 ## Integration with Swap Flow
 
 When a user makes a swap:
+
 1. Frontend checks if user has used a referral code (GET /referrals/usage/:address)
 2. If yes, include referral code in swap creation
 3. Backend stores swap with referral code and USD value

--- a/scripts/referral-rewards.ts
+++ b/scripts/referral-rewards.ts
@@ -38,7 +38,7 @@ const userPrisma = new UserPrismaClient();
 const RFOX_STAKING_CONTRACT = process.env.RFOX_STAKING_CONTRACT || '0x...';
 
 async function getFoxPriceUsd(): Promise<number> {
-  return 0.10;
+  return 0.1;
 }
 
 async function calculateReferralRewards(
@@ -47,7 +47,9 @@ async function calculateReferralRewards(
   totalFoxToDistribute: number,
   distributionName: string,
 ): Promise<ReferralRewardDistribution> {
-  console.log(`Calculating referral rewards from ${startDate.toISOString()} to ${endDate.toISOString()}`);
+  console.log(
+    `Calculating referral rewards from ${startDate.toISOString()} to ${endDate.toISOString()}`,
+  );
   console.log(`Total FOX to distribute: ${totalFoxToDistribute}`);
 
   const swaps = await swapPrisma.swap.findMany({
@@ -140,8 +142,12 @@ async function calculateReferralRewards(
       continue;
     }
 
-    const percentageOfTotal = totalVolume > 0 ? (stats.totalVolumeUsd / totalVolume) * 100 : 0;
-    const foxReward = totalVolume > 0 ? (stats.totalVolumeUsd / totalVolume) * totalFoxToDistribute : 0;
+    const percentageOfTotal =
+      totalVolume > 0 ? (stats.totalVolumeUsd / totalVolume) * 100 : 0;
+    const foxReward =
+      totalVolume > 0
+        ? (stats.totalVolumeUsd / totalVolume) * totalFoxToDistribute
+        : 0;
 
     rewards.push({
       referralCode: code,
@@ -162,7 +168,9 @@ async function calculateReferralRewards(
     safeTxData.operation.push(0);
   }
 
-  rewards.sort((a, b) => parseFloat(b.totalVolumeUsd) - parseFloat(a.totalVolumeUsd));
+  rewards.sort(
+    (a, b) => parseFloat(b.totalVolumeUsd) - parseFloat(a.totalVolumeUsd),
+  );
 
   const distribution: ReferralRewardDistribution = {
     id: `dist_${Date.now()}`,
@@ -179,14 +187,19 @@ async function calculateReferralRewards(
   return distribution;
 }
 
-function encodeDepositFunctionData(userAddress: string, amount: string): string {
+function encodeDepositFunctionData(
+  userAddress: string,
+  amount: string,
+): string {
   const functionSelector = '47e7ef24';
   const addressParam = userAddress.slice(2).padStart(64, '0');
   const amountParam = BigInt(amount).toString(16).padStart(64, '0');
   return `${functionSelector}${addressParam}${amountParam}`;
 }
 
-async function saveDistribution(distribution: ReferralRewardDistribution): Promise<void> {
+async function saveDistribution(
+  distribution: ReferralRewardDistribution,
+): Promise<void> {
   const outputDir = path.join(__dirname, '../distributions');
   if (!fs.existsSync(outputDir)) {
     fs.mkdirSync(outputDir, { recursive: true });
@@ -199,8 +212,13 @@ async function saveDistribution(distribution: ReferralRewardDistribution): Promi
   console.log(`Distribution saved to: ${filepath}`);
 }
 
-async function generateSafeTransactionFile(distributionId: string): Promise<void> {
-  const distributionFile = path.join(__dirname, `../distributions/${distributionId}.json`);
+async function generateSafeTransactionFile(
+  distributionId: string,
+): Promise<void> {
+  const distributionFile = path.join(
+    __dirname,
+    `../distributions/${distributionId}.json`,
+  );
 
   if (!fs.existsSync(distributionFile)) {
     throw new Error(`Distribution file not found: ${distributionFile}`);
@@ -224,7 +242,10 @@ async function generateSafeTransactionFile(distributionId: string): Promise<void
 }
 
 async function printDistributionStats(distributionId: string): Promise<void> {
-  const distributionFile = path.join(__dirname, `../distributions/${distributionId}.json`);
+  const distributionFile = path.join(
+    __dirname,
+    `../distributions/${distributionId}.json`,
+  );
 
   if (!fs.existsSync(distributionFile)) {
     throw new Error(`Distribution file not found: ${distributionFile}`);
@@ -243,10 +264,16 @@ async function printDistributionStats(distributionId: string): Promise<void> {
   console.log('\n=== Top 10 Referrers ===');
 
   distribution.rewards.slice(0, 10).forEach((reward, index) => {
-    console.log(`${index + 1}. ${reward.referralCode} (${reward.ownerAddress})`);
-    console.log(`   Volume: $${reward.totalVolumeUsd} (${reward.percentageOfTotal}%)`);
+    console.log(
+      `${index + 1}. ${reward.referralCode} (${reward.ownerAddress})`,
+    );
+    console.log(
+      `   Volume: $${reward.totalVolumeUsd} (${reward.percentageOfTotal}%)`,
+    );
     console.log(`   FOX Reward: ${reward.foxReward}`);
-    console.log(`   Swaps: ${reward.swapCount} | Unique Referees: ${reward.uniqueReferees}`);
+    console.log(
+      `   Swaps: ${reward.swapCount} | Unique Referees: ${reward.uniqueReferees}`,
+    );
   });
 }
 
@@ -260,9 +287,15 @@ async function main() {
         const startDate = new Date(args[1]);
         const endDate = new Date(args[2]);
         const totalFox = parseFloat(args[3]);
-        const name = args[4] || `Distribution ${startDate.toISOString().split('T')[0]}`;
+        const name =
+          args[4] || `Distribution ${startDate.toISOString().split('T')[0]}`;
 
-        const distribution = await calculateReferralRewards(startDate, endDate, totalFox, name);
+        const distribution = await calculateReferralRewards(
+          startDate,
+          endDate,
+          totalFox,
+          name,
+        );
         await saveDistribution(distribution);
         await printDistributionStats(distribution.id);
         break;
@@ -283,7 +316,9 @@ async function main() {
       default:
         console.log('Usage:');
         console.log('  calculate <start-date> <end-date> <total-fox> [name]');
-        console.log('    Example: calculate 2024-01-01 2024-01-31 10000 "January 2024"');
+        console.log(
+          '    Example: calculate 2024-01-01 2024-01-31 10000 "January 2024"',
+        );
         console.log('');
         console.log('  generate <distribution-id>');
         console.log('    Example: generate dist_1234567890');

--- a/tests/TESTING.md
+++ b/tests/TESTING.md
@@ -13,10 +13,10 @@ All 3 backend NestJS services must be running:
 yarn start:dev
 ```
 
-| Service | Port | Database |
-|---------|------|----------|
-| swap-service | 3001 | `swap_service` (PostgreSQL) |
-| user-service | 3002 | `user_service` (PostgreSQL) |
+| Service               | Port | Database                             |
+| --------------------- | ---- | ------------------------------------ |
+| swap-service          | 3001 | `swap_service` (PostgreSQL)          |
+| user-service          | 3002 | `user_service` (PostgreSQL)          |
 | notifications-service | 3003 | `notifications_service` (PostgreSQL) |
 
 PostgreSQL must be running on `localhost:5432` (Docker).
@@ -36,6 +36,7 @@ node tests/test-all-swappers.mjs
 ```
 
 The script runs 4 phases:
+
 1. **Cleanup** — Marks old `test-*` swaps as FAILED via `DELETE /swaps/test-cleanup` to clear the polling queue
 2. **Create** — POSTs fake pending swaps to `POST /swaps` for each swapper
 3. **Poll** — Polls ALL swaps in parallel for up to 2 minutes total
@@ -73,48 +74,51 @@ For each swapper, the test verifies:
 
 ### Resolves to SUCCESS (14 swappers)
 
-| Swapper | Status Check Method | Test Tx Type | Affiliate Verified | Notes |
-|---------|--------------------|--------------|--------------------|-------|
-| THORChain | Midgard API (`/thorchain/tx/{hash}`) | Real BTC swap tx | No (not a real affiliate tx) | Uses `VITE_THORCHAIN_NODE_URL` |
-| MAYAChain | Midgard API (`/mayachain/tx/{hash}`) | Real ZEC swap tx | No | Uses `VITE_MAYACHAIN_NODE_URL` |
-| CowSwap | CoW Protocol API (`/v1/trades?orderUid=`) | Real orderUid | No | `sellTxHash` IS the orderUid |
-| 0x (Zrx) | `checkEvmSwapStatus` (unchained) | Any confirmed ETH tx | No | Simple on-chain confirmation |
-| Portals | `checkEvmSwapStatus` (unchained) | Any confirmed ETH tx | No | Simple on-chain confirmation |
-| Bebop | `checkEvmSwapStatus` (unchained) | Any confirmed ETH tx | No | Simple on-chain confirmation |
-| Jupiter | `checkSolanaSwapStatus` (unchained) | Successful Solana tx | Yes (bps=60) | MUST be a successful tx (no `transactionError`) |
-| AVNU | `checkStarknetSwapStatus` (Starknet RPC) | Real Starknet tx | Yes (bps=60) | Uses `VITE_STARKNET_NODE_URL` |
-| Sun.io | `checkTronSwapStatus` (Tron RPC) | Real Tron tx | Yes (bps=60) | Uses `VITE_TRON_NODE_URL` |
-| Cetus | `checkSuiSwapStatus` (Sui RPC) | Confirmed Sui tx digest | Yes (bps=60) | Requires `receiveAddress` on swap |
-| Relay | Relay API (`/intents/status/v2?requestId=`) | Real Relay requestId | No (bps=85 from Relay) | Requires `metadata.relayTransactionMetadata.relayId` |
-| Arbitrum Bridge | `checkEvmSwapStatus` (unchained) | Confirmed Arbitrum tx | No | L2→L1 withdraw path returns SUCCESS on tx confirmation |
-| ButterSwap | `checkEvmSwapStatus` (unchained) | Any confirmed ETH tx | No | Same-chain EVM path, no bridge indexer needed |
-| NEAR Intents | 1Click API (`/v0/status?depositAddress=`) | Real completed deposit | No (bps=25 from real tx) | Requires `metadata.nearIntentsSpecific.depositAddress` |
+| Swapper         | Status Check Method                         | Test Tx Type            | Affiliate Verified           | Notes                                                  |
+| --------------- | ------------------------------------------- | ----------------------- | ---------------------------- | ------------------------------------------------------ |
+| THORChain       | Midgard API (`/thorchain/tx/{hash}`)        | Real BTC swap tx        | No (not a real affiliate tx) | Uses `VITE_THORCHAIN_NODE_URL`                         |
+| MAYAChain       | Midgard API (`/mayachain/tx/{hash}`)        | Real ZEC swap tx        | No                           | Uses `VITE_MAYACHAIN_NODE_URL`                         |
+| CowSwap         | CoW Protocol API (`/v1/trades?orderUid=`)   | Real orderUid           | No                           | `sellTxHash` IS the orderUid                           |
+| 0x (Zrx)        | `checkEvmSwapStatus` (unchained)            | Any confirmed ETH tx    | No                           | Simple on-chain confirmation                           |
+| Portals         | `checkEvmSwapStatus` (unchained)            | Any confirmed ETH tx    | No                           | Simple on-chain confirmation                           |
+| Bebop           | `checkEvmSwapStatus` (unchained)            | Any confirmed ETH tx    | No                           | Simple on-chain confirmation                           |
+| Jupiter         | `checkSolanaSwapStatus` (unchained)         | Successful Solana tx    | Yes (bps=60)                 | MUST be a successful tx (no `transactionError`)        |
+| AVNU            | `checkStarknetSwapStatus` (Starknet RPC)    | Real Starknet tx        | Yes (bps=60)                 | Uses `VITE_STARKNET_NODE_URL`                          |
+| Sun.io          | `checkTronSwapStatus` (Tron RPC)            | Real Tron tx            | Yes (bps=60)                 | Uses `VITE_TRON_NODE_URL`                              |
+| Cetus           | `checkSuiSwapStatus` (Sui RPC)              | Confirmed Sui tx digest | Yes (bps=60)                 | Requires `receiveAddress` on swap                      |
+| Relay           | Relay API (`/intents/status/v2?requestId=`) | Real Relay requestId    | No (bps=85 from Relay)       | Requires `metadata.relayTransactionMetadata.relayId`   |
+| Arbitrum Bridge | `checkEvmSwapStatus` (unchained)            | Confirmed Arbitrum tx   | No                           | L2→L1 withdraw path returns SUCCESS on tx confirmation |
+| ButterSwap      | `checkEvmSwapStatus` (unchained)            | Any confirmed ETH tx    | No                           | Same-chain EVM path, no bridge indexer needed          |
+| NEAR Intents    | 1Click API (`/v0/status?depositAddress=`)   | Real completed deposit  | No (bps=25 from real tx)     | Requires `metadata.nearIntentsSpecific.depositAddress` |
 
 ### Expected to Stay PENDING (3 swappers)
 
-| Swapper | Reason | How to Fix |
-|---------|--------|------------|
-| STON.fi | TON chain adapter `parseTx()` needs sender address; falls back when no `quoteId` | Provide real `quoteId` from STON.fi/Omniston SDK |
-| Across | Across deposit status API won't recognize a random ETH tx as a valid deposit | Use a real Across bridge deposit tx hash |
-| Chainflip | Broker API returns 404 for unknown swapId; the API key is broker-specific | Use a real swap ID created through this specific broker |
+| Swapper   | Reason                                                                           | How to Fix                                              |
+| --------- | -------------------------------------------------------------------------------- | ------------------------------------------------------- |
+| STON.fi   | TON chain adapter `parseTx()` needs sender address; falls back when no `quoteId` | Provide real `quoteId` from STON.fi/Omniston SDK        |
+| Across    | Across deposit status API won't recognize a random ETH tx as a valid deposit     | Use a real Across bridge deposit tx hash                |
+| Chainflip | Broker API returns 404 for unknown swapId; the API key is broker-specific        | Use a real swap ID created through this specific broker |
 
 ### Not Tested
 
-| Swapper | Reason |
-|---------|--------|
-| Test | Internal test swapper, no real implementation |
+| Swapper | Reason                                        |
+| ------- | --------------------------------------------- |
+| Test    | Internal test swapper, no real implementation |
 
 ## Affiliate Verification Behavior
 
 There are two types of affiliate verification:
 
 ### On-chain Verification (THORChain, MAYAChain, CowSwap, 0x, Portals, Bebop, Relay, Arbitrum Bridge, ButterSwap)
+
 These check the actual transaction on-chain or via protocol APIs for affiliate fee data. Test txs are NOT real ShapeShift affiliate swaps, so they correctly report `hasAffiliate=false`. This is **expected behavior** — the verification logic works, it just doesn't find affiliate data in random txs.
 
 ### Metadata-based Verification (Jupiter, AVNU, Sun.io, Cetus, STON.fi)
+
 These check the swap's `affiliateBps` from the enriched metadata passed during verification. Since we set `affiliateBps=60` in the test payload, these correctly report `hasAffiliate=true, affiliateBps=60`.
 
 ### API-based Verification (NEAR Intents, Relay)
+
 These read affiliate data from the external API response. The real NEAR Intents deposit shows `bps=25` (the actual appFee from that transaction). Relay shows `bps=85` from the Relay API.
 
 ## Updating Test Data
@@ -124,6 +128,7 @@ These read affiliate data from the external API response. The real NEAR Intents 
 Some tx hashes may stop working over time (pruned from RPC nodes, API changes). To update:
 
 1. **EVM txs (0x, Portals, Bebop, ButterSwap, Arbitrum Bridge)**: Any confirmed mainnet tx works:
+
    ```bash
    # Ethereum
    curl -s 'https://api.ethereum.shapeshift.com/api/v1/tx/0x<ANY_ETH_TX_HASH>'
@@ -133,19 +138,21 @@ Some tx hashes may stop working over time (pruned from RPC nodes, API changes). 
    ```
 
 2. **Solana tx (Jupiter)**: Must be a SUCCESSFUL tx (no `transactionError`):
+
    ```bash
    # Find a recent successful Jupiter tx
    curl -s -X POST "https://api.solana.shapeshift.com/api/v1/jsonrpc" \
      -H "Content-Type: application/json" \
      -d '{"jsonrpc":"2.0","id":1,"method":"getSignaturesForAddress","params":["JUP6LkbZbjS1jKKwapdHNy74zcZ3tLUZoi5QNyVTaV4",{"limit":30}]}'
    # Pick one where "err": null
-   
+
    # Verify it's successful
    curl -s "https://api.solana.shapeshift.com/api/v1/tx/<SIGNATURE>"
    # Should have "transactionError": null
    ```
 
 3. **Starknet tx (AVNU)**: Any confirmed Starknet tx:
+
    ```bash
    curl -s -X POST "https://rpc.starknet.lava.build" \
      -H "Content-Type: application/json" \
@@ -154,6 +161,7 @@ Some tx hashes may stop working over time (pruned from RPC nodes, API changes). 
    ```
 
 4. **Tron tx (Sun.io)**: Any confirmed Tron tx:
+
    ```bash
    curl -s "https://api.trongrid.io/walletsolidity/gettransactioninfobyid" \
      -X POST -H "Content-Type: application/json" \
@@ -162,6 +170,7 @@ Some tx hashes may stop working over time (pruned from RPC nodes, API changes). 
    ```
 
 5. **Sui tx digest (Cetus)**: Any confirmed Sui tx:
+
    ```bash
    curl -s -X POST https://fullnode.mainnet.sui.io:443 \
      -H "Content-Type: application/json" \
@@ -170,23 +179,27 @@ Some tx hashes may stop working over time (pruned from RPC nodes, API changes). 
    ```
 
 6. **THORChain tx**: Must be a real THORChain swap visible on Midgard:
+
    ```bash
    curl -s "https://thornode.ninerealms.com/thorchain/tx/<TX_HASH>"
    # Should return observed_tx with swap data
    ```
 
 7. **MAYAChain tx**: Same as THORChain but on MAYAChain Midgard:
+
    ```bash
    curl -s "https://mayanode.mayachain.info/mayachain/tx/<TX_HASH>"
    ```
 
 8. **CowSwap orderUid**: Get from CoW Protocol API:
+
    ```bash
    curl -s "https://api.cow.fi/mainnet/api/v1/orders/<ORDER_UID>"
    # Should return order with status: "fulfilled"
    ```
 
 9. **Relay requestId**: Get from Relay API:
+
    ```bash
    curl -s "https://api.relay.link/intents/status/v2?requestId=<REQUEST_ID>"
    # Should return status data
@@ -282,12 +295,12 @@ Sun.io, AVNU, STON.fi, Across, Arbitrum Bridge, Test
 
 ### Metadata Requirements per Swapper
 
-| Swapper | Required Metadata | Example |
-|---------|-------------------|---------|
-| Relay | `relayTransactionMetadata.relayId` | `{ relayTransactionMetadata: { relayId: "0xabc..." } }` |
-| Chainflip | `chainflipSwapId` (integer) | `{ chainflipSwapId: 12345 }` |
+| Swapper      | Required Metadata                    | Example                                                  |
+| ------------ | ------------------------------------ | -------------------------------------------------------- |
+| Relay        | `relayTransactionMetadata.relayId`   | `{ relayTransactionMetadata: { relayId: "0xabc..." } }`  |
+| Chainflip    | `chainflipSwapId` (integer)          | `{ chainflipSwapId: 12345 }`                             |
 | NEAR Intents | `nearIntentsSpecific.depositAddress` | `{ nearIntentsSpecific: { depositAddress: "1Q7c..." } }` |
-| All others | None required | `{}` |
+| All others   | None required                        | `{}`                                                     |
 
 ## Polling Behavior
 
@@ -384,13 +397,13 @@ test-all-swappers.mjs
 
 ## Key Files
 
-| File | Purpose |
-|------|---------|
-| `tests/test-all-swappers.mjs` | The test script |
-| `apps/swap-service/src/swaps/swaps.service.ts` | Swap creation + pollSwapStatus |
-| `apps/swap-service/src/swaps/swaps.controller.ts` | REST endpoints including test-cleanup |
-| `apps/swap-service/src/polling/swap-polling.service.ts` | 5s cron loop |
-| `apps/swap-service/src/verification/swap-verification.service.ts` | All 18 affiliate verifiers |
-| `apps/swap-service/prisma/schema.prisma` | Swap model (53 columns) |
-| `packages/shared-types/src/index.ts` | CreateSwapDto, UpdateSwapStatusDto |
-| `.env` | All RPC/API URLs |
+| File                                                              | Purpose                               |
+| ----------------------------------------------------------------- | ------------------------------------- |
+| `tests/test-all-swappers.mjs`                                     | The test script                       |
+| `apps/swap-service/src/swaps/swaps.service.ts`                    | Swap creation + pollSwapStatus        |
+| `apps/swap-service/src/swaps/swaps.controller.ts`                 | REST endpoints including test-cleanup |
+| `apps/swap-service/src/polling/swap-polling.service.ts`           | 5s cron loop                          |
+| `apps/swap-service/src/verification/swap-verification.service.ts` | All 18 affiliate verifiers            |
+| `apps/swap-service/prisma/schema.prisma`                          | Swap model (53 columns)               |
+| `packages/shared-types/src/index.ts`                              | CreateSwapDto, UpdateSwapStatusDto    |
+| `.env`                                                            | All RPC/API URLs                      |

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,11 +6,12 @@
     "types": ["node"],
     "skipLibCheck": true,
     "moduleResolution": "node",
+    "ignoreDeprecations": "5.0",
     "resolveJsonModule": true,
     "esModuleInterop": true,
     "experimentalDecorators": true,
     "emitDecoratorMetadata": true,
-    "strictPropertyInitialization": false,
+    "strictPropertyInitialization": false
   },
   "include": [
     "apps/**/*",


### PR DESCRIPTION
## Description

Housekeeping pass to get the project cleanly formatted and lint-clean so ongoing work doesn't fight the tooling.

- **tsconfig**: added `ignoreDeprecations` to silence TS 5.9 warnings (unblocks `@shapeshift/shared-types` build).
- **SIWE typing**: `SiweAuthGuard` now exports a `SiweRequest` interface (Express `Request` + `siweAddress: string`) and uses `getRequest<SiweRequest>()`. `affiliate.controller.ts` imports that type instead of `@Req() req: any`, clearing all the `no-unsafe-*` lint errors in both files.
- **Formatting**: Prettier pass across README, TESTING.md, referral-rewards script + README, railway.json configs, per-service tsconfigs, and `app.module.ts` / `affiliate.service.ts`. No functional changes.

## Testing

- [ ] `yarn lint` — no errors
- [ ] `yarn format` — no diffs
- [ ] `yarn build` — all workspaces compile
- [ ] SIWE-protected routes (`POST /v1/affiliate`, `PATCH /v1/affiliate/:address`, `POST /v1/affiliate/claim-code`) still behave identically — type-only refactor