### PR TITLE
feat(swap-service): cursor pagination for swap history

### DIFF
--- a/apps/swap-service/src/swaps/swaps.controller.ts
+++ b/apps/swap-service/src/swaps/swaps.controller.ts
@@ -51,16 +51,18 @@ export class SwapsController {
   async getSwapsByUser(
     @Param('userId') userId: string,
     @Query('limit', new DefaultValuePipe(50), ParseIntPipe) limit: number,
+    @Query('cursor') cursor?: string,
   ) {
-    return this.swapsService.getSwapsByUser(userId, limit);
+    return this.swapsService.getSwapsByUser(userId, { limit, cursor });
   }
 
   @Get('account/:accountId')
   async getSwapsByAccountId(
     @Param('accountId') accountId: string,
     @Query('limit', new DefaultValuePipe(50), ParseIntPipe) limit: number,
+    @Query('cursor') cursor?: string,
   ) {
-    return this.swapsService.getSwapsByAccountId(accountId, limit);
+    return this.swapsService.getSwapsByAccountId(accountId, { limit, cursor });
   }
 
   @Get('pending')

--- a/apps/swap-service/src/swaps/swaps.service.ts
+++ b/apps/swap-service/src/swaps/swaps.service.ts
@@ -290,38 +290,45 @@ export class SwapsService {
     }
   }
 
-  async getSwapsByUser(userId: string, limit = 50) {
-    const swaps = await this.prisma.swap.findMany({
-      where: { userId },
-      orderBy: { createdAt: 'desc' },
-      take: limit,
-    });
-
-    return swaps.map((swap) => ({
-      ...swap,
-      sellAsset: swap.sellAsset as Asset,
-      buyAsset: swap.buyAsset as Asset,
-    }));
+  async getSwapsByUser(
+    userId: string,
+    { limit = 50, cursor }: { limit?: number; cursor?: string } = {},
+  ) {
+    return this.paginateSwaps({ userId }, { limit, cursor });
   }
 
-  async getSwapsByAccountId(accountId: string, limit = 50) {
+  async getSwapsByAccountId(
+    accountId: string,
+    { limit = 50, cursor }: { limit?: number; cursor?: string } = {},
+  ) {
     const hashedAccountId = hashAccountId(accountId);
-    const swaps = await this.prisma.swap.findMany({
-      where: {
+
+    return this.paginateSwaps(
+      {
         OR: [
           { sellAccountId: hashedAccountId },
           { buyAccountId: hashedAccountId },
         ],
       },
-      orderBy: { createdAt: 'desc' },
+      { limit, cursor },
+    );
+  }
+
+  private async paginateSwaps(
+    where: Prisma.SwapWhereInput,
+    { limit, cursor }: { limit: number; cursor?: string },
+  ) {
+    const items = await this.prisma.swap.findMany({
+      where,
+      orderBy: [{ createdAt: 'desc' }, { id: 'desc' }],
       take: limit,
+      ...(cursor ? { cursor: { id: cursor }, skip: 1 } : {}),
     });
 
-    return swaps.map((swap) => ({
-      ...swap,
-      sellAsset: swap.sellAsset,
-      buyAsset: swap.buyAsset,
-    }));
+    const nextCursor =
+      items.length === limit ? items[items.length - 1].id : null;
+
+    return { items, nextCursor };
   }
 
   async getPendingSwaps() {

--- a/apps/swap-service/src/websocket/websocket.gateway.ts
+++ b/apps/swap-service/src/websocket/websocket.gateway.ts
@@ -49,7 +49,7 @@ export class WebsocketGateway
 
   @SubscribeMessage('getSwaps')
   async handleGetSwaps(
-    @MessageBody() data: { limit?: number },
+    @MessageBody() data: { limit?: number; cursor?: string },
     @ConnectedSocket() client: AuthenticatedSocket,
   ) {
     if (!client.userId) {
@@ -57,11 +57,11 @@ export class WebsocketGateway
     }
 
     try {
-      const swaps = await this.swapsService.getSwapsByUser(
+      const { items, nextCursor } = await this.swapsService.getSwapsByUser(
         client.userId,
-        data.limit || 50,
+        { limit: data.limit || 50, cursor: data.cursor },
       );
-      return { success: true, swaps };
+      return { success: true, swaps: items, nextCursor };
     } catch (error) {
       this.logger.error('Failed to get swaps', error);
       return { error: 'Failed to get swaps' };


### PR DESCRIPTION
## Description

Adds cursor-based pagination to `getSwapsByUser` and `getSwapsByAccountId`, replacing the prior limit-only cap (which truncated at 50 with no way to reach older records).

- Service methods now accept `{ limit, cursor }` and return `{ items, nextCursor }`.
- Stable ordering via `[createdAt desc, id desc]` tiebreaker on the unique cuid primary key.
- Prisma cursor form: `cursor: { id }, skip: 1, take: limit`.
- `nextCursor` is the last item's `id` when a full page is returned, otherwise `null`.
- REST: `GET /swaps/user/:userId?limit=50&cursor=<id>` and `GET /swaps/account/:accountId?limit=50&cursor=<id>`.
- WS: `getSwaps` message now accepts `{ limit?, cursor? }` and response includes `nextCursor` alongside the existing `swaps` field.

Response shape is a breaking change for any existing caller — response is now `{ items, nextCursor }` (REST) / `{ success, swaps, nextCursor }` (WS).

## Testing

- [ ] `yarn build` passes
- [ ] `yarn lint` passes
- [ ] First page: `GET /swaps/user/:userId?limit=10` returns 10 items and a `nextCursor`
- [ ] Subsequent page: `GET /swaps/user/:userId?limit=10&cursor=<nextCursor>` returns the next 10, older, non-overlapping
- [ ] Last page under `limit`: returns remaining items with `nextCursor: null`
- [ ] Same checks for `/swaps/account/:accountId`
- [ ] WS `getSwaps` round-trip honors `cursor` and returns `nextCursor`