### PR TITLE
refactor(swap-service): unify fee calc, simplify polling, extract types

### DIFF
--- a/apps/swap-service/package.json
+++ b/apps/swap-service/package.json
@@ -14,9 +14,6 @@
   "dependencies": {
     "@shapeshift/shared-types": "workspace:*",
     "@shapeshift/shared-utils": "workspace:*",
-    "axios": "^1.6.2",
-    "class-transformer": "^0.5.1",
-    "class-validator": "^0.14.3",
     "jsonwebtoken": "^9.0.3",
     "siwe": "^3.0.0"
   },

--- a/apps/swap-service/src/swaps/swapper-config.ts
+++ b/apps/swap-service/src/swaps/swapper-config.ts
@@ -1,0 +1,75 @@
+import type { ChainId } from '@shapeshiftoss/caip'
+
+import type { CosmosSdkChainAdapterService } from '../lib/chain-adapters/cosmos-sdk.service'
+import type { EvmChainAdapterService } from '../lib/chain-adapters/evm.service'
+import type { NearChainAdapterService } from '../lib/chain-adapters/near.service'
+import type { SolanaChainAdapterService } from '../lib/chain-adapters/solana.service'
+import type { StarknetChainAdapterService } from '../lib/chain-adapters/starknet.service'
+import type { SuiChainAdapterService } from '../lib/chain-adapters/sui.service'
+import type { TonChainAdapterService } from '../lib/chain-adapters/ton.service'
+import type { TronChainAdapterService } from '../lib/chain-adapters/tron.service'
+import type { UtxoChainAdapterService } from '../lib/chain-adapters/utxo.service'
+
+export const getSwapperConfig = () => ({
+  VITE_UNCHAINED_THORCHAIN_HTTP_URL: process.env.VITE_UNCHAINED_THORCHAIN_HTTP_URL || '',
+  VITE_UNCHAINED_MAYACHAIN_HTTP_URL: process.env.VITE_UNCHAINED_MAYACHAIN_HTTP_URL || '',
+  VITE_UNCHAINED_COSMOS_HTTP_URL: process.env.VITE_UNCHAINED_COSMOS_HTTP_URL || '',
+  VITE_THORCHAIN_NODE_URL: process.env.VITE_THORCHAIN_NODE_URL || '',
+  VITE_MAYACHAIN_NODE_URL: process.env.VITE_MAYACHAIN_NODE_URL || '',
+  VITE_COWSWAP_BASE_URL: process.env.VITE_COWSWAP_BASE_URL || '',
+  VITE_CHAINFLIP_API_KEY: process.env.VITE_CHAINFLIP_API_KEY || '',
+  VITE_CHAINFLIP_API_URL: process.env.VITE_CHAINFLIP_API_URL || '',
+  VITE_RELAY_API_URL: process.env.VITE_RELAY_API_URL || '',
+  VITE_PORTALS_BASE_URL: process.env.VITE_PORTALS_BASE_URL || '',
+  VITE_ZRX_BASE_URL: process.env.VITE_ZRX_BASE_URL || '',
+  VITE_THORCHAIN_MIDGARD_URL: process.env.VITE_THORCHAIN_MIDGARD_URL || '',
+  VITE_MAYACHAIN_MIDGARD_URL: process.env.VITE_MAYACHAIN_MIDGARD_URL || '',
+  VITE_UNCHAINED_BITCOIN_HTTP_URL: process.env.VITE_UNCHAINED_BITCOIN_HTTP_URL || '',
+  VITE_UNCHAINED_DOGECOIN_HTTP_URL: process.env.VITE_UNCHAINED_DOGECOIN_HTTP_URL || '',
+  VITE_UNCHAINED_LITECOIN_HTTP_URL: process.env.VITE_UNCHAINED_LITECOIN_HTTP_URL || '',
+  VITE_UNCHAINED_BITCOINCASH_HTTP_URL: process.env.VITE_UNCHAINED_BITCOINCASH_HTTP_URL || '',
+  VITE_UNCHAINED_ETHEREUM_HTTP_URL: process.env.VITE_UNCHAINED_ETHEREUM_HTTP_URL || '',
+  VITE_UNCHAINED_AVALANCHE_HTTP_URL: process.env.VITE_UNCHAINED_AVALANCHE_HTTP_URL || '',
+  VITE_UNCHAINED_BNBSMARTCHAIN_HTTP_URL: process.env.VITE_UNCHAINED_BNBSMARTCHAIN_HTTP_URL || '',
+  VITE_UNCHAINED_BASE_HTTP_URL: process.env.VITE_UNCHAINED_BASE_HTTP_URL || '',
+  VITE_NEAR_INTENTS_API_KEY: process.env.VITE_NEAR_INTENTS_API_KEY || '',
+  VITE_BEBOP_API_KEY: process.env.VITE_BEBOP_API_KEY || '',
+  VITE_TENDERLY_API_KEY: process.env.VITE_TENDERLY_API_KEY || '',
+  VITE_TENDERLY_ACCOUNT_SLUG: process.env.VITE_TENDERLY_ACCOUNT_SLUG || '',
+  VITE_TENDERLY_PROJECT_SLUG: process.env.VITE_TENDERLY_PROJECT_SLUG || '',
+  VITE_TRON_NODE_URL: process.env.VITE_TRON_NODE_URL || '',
+  VITE_SUI_NODE_URL: process.env.VITE_SUI_NODE_URL || '',
+  VITE_ACROSS_API_URL: process.env.VITE_ACROSS_API_URL || '',
+  VITE_ACROSS_INTEGRATOR_ID: process.env.VITE_ACROSS_INTEGRATOR_ID || '',
+  VITE_DEBRIDGE_API_URL: process.env.VITE_DEBRIDGE_API_URL || '',
+  VITE_FEATURE_THORCHAINSWAP_LONGTAIL: true,
+  VITE_FEATURE_THORCHAINSWAP_L1_TO_LONGTAIL: true,
+  VITE_FEATURE_CHAINFLIP_SWAP_DCA: true,
+})
+
+type ChainAdapterServices = {
+  evmChainAdapterService: EvmChainAdapterService
+  utxoChainAdapterService: UtxoChainAdapterService
+  cosmosSdkChainAdapterService: CosmosSdkChainAdapterService
+  solanaChainAdapterService: SolanaChainAdapterService
+  tronChainAdapterService: TronChainAdapterService
+  suiChainAdapterService: SuiChainAdapterService
+  nearChainAdapterService: NearChainAdapterService
+  starknetChainAdapterService: StarknetChainAdapterService
+  tonChainAdapterService: TonChainAdapterService
+}
+
+export const buildChainAdapterAsserts = (services: ChainAdapterServices) => ({
+  assertGetEvmChainAdapter: (chainId: ChainId) => services.evmChainAdapterService.assertGetEvmChainAdapter(chainId),
+  assertGetUtxoChainAdapter: (chainId: ChainId) => services.utxoChainAdapterService.assertGetUtxoChainAdapter(chainId),
+  assertGetCosmosSdkChainAdapter: (chainId: ChainId) =>
+    services.cosmosSdkChainAdapterService.assertGetCosmosSdkChainAdapter(chainId),
+  assertGetSolanaChainAdapter: (chainId: ChainId) =>
+    services.solanaChainAdapterService.assertGetSolanaChainAdapter(chainId),
+  assertGetTronChainAdapter: (chainId: ChainId) => services.tronChainAdapterService.assertGetTronChainAdapter(chainId),
+  assertGetSuiChainAdapter: (chainId: ChainId) => services.suiChainAdapterService.assertGetSuiChainAdapter(chainId),
+  assertGetNearChainAdapter: (chainId: ChainId) => services.nearChainAdapterService.assertGetNearChainAdapter(chainId),
+  assertGetStarknetChainAdapter: (chainId: ChainId) =>
+    services.starknetChainAdapterService.assertGetStarknetChainAdapter(chainId),
+  assertGetTonChainAdapter: (chainId: ChainId) => services.tonChainAdapterService.assertGetTonChainAdapter(chainId),
+})

--- a/apps/swap-service/src/swaps/swaps.controller.ts
+++ b/apps/swap-service/src/swaps/swaps.controller.ts
@@ -38,6 +38,11 @@ export class SwapsController {
     return this.swapsService.updateSwapStatus({ swapId, ...data })
   }
 
+  @Get('pending')
+  async getPendingSwaps() {
+    return this.swapsService.getPendingSwaps()
+  }
+
   @Get(':swapId')
   async getSwapById(@Param('swapId') swapId: string) {
     const swap = await this.swapsService.getSwapById(swapId)
@@ -53,11 +58,6 @@ export class SwapsController {
   @Get('account/:accountId')
   async getSwapsByAccountId(@Param('accountId') accountId: string, @Query(PaginationPipe) query: PaginationQueryDto) {
     return this.swapsService.getSwapsByAccountId(accountId, query)
-  }
-
-  @Get('pending')
-  async getPendingSwaps() {
-    return this.swapsService.getPendingSwaps()
   }
 
   @Get('referral-fees/:referralCode')

--- a/apps/swap-service/src/swaps/swaps.controller.ts
+++ b/apps/swap-service/src/swaps/swaps.controller.ts
@@ -1,25 +1,25 @@
 import {
   Body,
   Controller,
-  DefaultValuePipe,
   Get,
   NotFoundException,
   Param,
   ParseDatePipe,
-  ParseIntPipe,
   Post,
   Put,
   Query,
+  ValidationPipe,
 } from '@nestjs/common'
 
 import type { CreateSwapDto, UpdateSwapStatusDto, VerifySwapAffiliateDto } from '@shapeshift/shared-types'
-import type { Asset } from '@shapeshiftoss/types'
 
 import { SwapVerificationService } from '../verification/swap-verification.service'
 
 import { SwapsService } from './swaps.service'
+import { PaginationQueryDto } from './types'
 
 const OptionalDatePipe = new ParseDatePipe({ optional: true })
+const PaginationPipe = new ValidationPipe({ transform: true, whitelist: true, forbidNonWhitelisted: true })
 
 @Controller('swaps')
 export class SwapsController {
@@ -38,22 +38,21 @@ export class SwapsController {
     return this.swapsService.updateSwapStatus({ swapId, ...data })
   }
 
+  @Get(':swapId')
+  async getSwapById(@Param('swapId') swapId: string) {
+    const swap = await this.swapsService.getSwapById(swapId)
+    if (!swap) throw new NotFoundException(`Swap ${swapId} not found`)
+    return swap
+  }
+
   @Get('user/:userId')
-  async getSwapsByUser(
-    @Param('userId') userId: string,
-    @Query('limit', new DefaultValuePipe(50), ParseIntPipe) limit: number,
-    @Query('cursor') cursor?: string,
-  ) {
-    return this.swapsService.getSwapsByUser(userId, { limit, cursor })
+  async getSwapsByUser(@Param('userId') userId: string, @Query(PaginationPipe) query: PaginationQueryDto) {
+    return this.swapsService.getSwapsByUser(userId, query)
   }
 
   @Get('account/:accountId')
-  async getSwapsByAccountId(
-    @Param('accountId') accountId: string,
-    @Query('limit', new DefaultValuePipe(50), ParseIntPipe) limit: number,
-    @Query('cursor') cursor?: string,
-  ) {
-    return this.swapsService.getSwapsByAccountId(accountId, { limit, cursor })
+  async getSwapsByAccountId(@Param('accountId') accountId: string, @Query(PaginationPipe) query: PaginationQueryDto) {
+    return this.swapsService.getSwapsByAccountId(accountId, query)
   }
 
   @Get('pending')
@@ -79,22 +78,15 @@ export class SwapsController {
     return this.swapsService.calculateAffiliateFees(affiliateAddress, startDate, endDate)
   }
 
-  @Get(':swapId')
-  async getSwap(@Param('swapId') swapId: string) {
-    const swap = await this.swapsService.findSwapBySwapId(swapId)
-    if (!swap) throw new NotFoundException(`Swap ${swapId} not found`)
-    return swap
-  }
-
   @Post(':swapId/verify-affiliate')
   async verifySwapAffiliate(@Param('swapId') swapId: string, @Body() data: Omit<VerifySwapAffiliateDto, 'swapId'>) {
-    const swap = await this.swapsService.findSwapBySwapId(swapId)
+    const swap = await this.swapsService.getSwapById(swapId)
     if (!swap) throw new NotFoundException(`Swap ${swapId} not found`)
 
     return this.swapVerificationService.verifySwapAffiliate(
       swapId,
       data.protocol || swap.swapperName,
-      (swap.sellAsset as Asset).chainId,
+      swap.sellAsset.chainId,
       data.txHash || swap.sellTxHash || undefined,
       swap.metadata as Record<string, any>,
     )

--- a/apps/swap-service/src/swaps/swaps.service.ts
+++ b/apps/swap-service/src/swaps/swaps.service.ts
@@ -25,13 +25,19 @@ import { TonChainAdapterService } from '../lib/chain-adapters/ton.service'
 import { TronChainAdapterService } from '../lib/chain-adapters/tron.service'
 import { UtxoChainAdapterService } from '../lib/chain-adapters/utxo.service'
 import { PrismaService } from '../prisma/prisma.service'
-import { getSwapperFeeStrategy, resolveAffiliateFeeAssetId } from '../utils/affiliateFeeAsset'
+import { resolveAffiliateFeeAssetId } from '../utils/affiliateFeeAsset'
 import { getNextCursor, swapCursorArgs } from '../utils/pagination'
 import { getAssetPriceUsd } from '../utils/pricing'
 import { SwapVerificationService } from '../verification/swap-verification.service'
 
-import { toSwap } from './types'
 import type { AffiliateVerificationDetails, PaginationOptions, Swap, UsdPrices } from './types'
+import {
+  estimateAffiliateFeeAmount,
+  formatAmount,
+  getAffiliateCommissionRate,
+  resolveFeeAssetPrice,
+  toSwap,
+} from './utils'
 
 @Injectable()
 export class SwapsService {
@@ -193,12 +199,6 @@ export class SwapsService {
     }
   }
 
-  private formatAmount(amount: string | number): string {
-    // Convert to number with up to 8 decimals, then remove trailing zeros
-    const num = bnOrZero(amount).toFixed(8)
-    return num.replace(/\.?0+$/, '')
-  }
-
   private async sendStatusUpdateNotification(
     swap: Pick<
       Swap,
@@ -221,8 +221,8 @@ export class SwapsService {
     switch (swap.status) {
       case 'SUCCESS': {
         title = 'Swap Completed!'
-        const sellAmount = this.formatAmount(baseUnitToPrecision(swap.sellAmountCryptoBaseUnit, sellAsset.precision))
-        const buyAmount = this.formatAmount(
+        const sellAmount = formatAmount(baseUnitToPrecision(swap.sellAmountCryptoBaseUnit, sellAsset.precision))
+        const buyAmount = formatAmount(
           baseUnitToPrecision(
             swap.actualBuyAmountCryptoBaseUnit || swap.expectedBuyAmountCryptoBaseUnit,
             buyAsset.precision,
@@ -459,15 +459,6 @@ export class SwapsService {
     }
   }
 
-  private getAffiliateCommissionRate(origin: string | null, verifiedBps: number, shapeshiftBps: number): number {
-    if (origin === 'web') {
-      // Referrer earns shapeshiftBps of volume (shapeshiftBps / verifiedBps of the fee).
-      return shapeshiftBps / verifiedBps
-    }
-    if (!origin || verifiedBps <= shapeshiftBps) return 0
-    return (verifiedBps - shapeshiftBps) / verifiedBps
-  }
-
   private calculateFeeForSwap(swap: {
     swapId: string
     swapperName: string
@@ -495,7 +486,7 @@ export class SwapsService {
       return { feeUsd: 0, volumeUsd: sellAmountUsd }
     }
 
-    const commissionRate = this.getAffiliateCommissionRate(swap.origin, verifiedBps, swap.shapeshiftBps)
+    const commissionRate = getAffiliateCommissionRate(swap.origin, verifiedBps, swap.shapeshiftBps)
 
     const verifiedSell = verificationDetails?.verifiedSellAmountCryptoBaseUnit
     const effectiveSellAmount = verifiedSell
@@ -506,14 +497,14 @@ export class SwapsService {
 
     let totalFeeUsd: number
     const feeAssetId = swap.affiliateFeeAssetId
-    const feeAssetPrice = this.resolveFeeAssetPrice(swap)
+    const feeAssetPrice = resolveFeeAssetPrice(swap)
 
     if (feeAssetId && feeAssetPrice) {
       const sellAssetObj = swap.sellAsset as Asset
       const buyAssetObj = swap.buyAsset as Asset
       const feeAmountBaseUnit =
         swap.actualAffiliateFeeAmountCryptoBaseUnit ??
-        this.estimateAffiliateFeeAmount(
+        estimateAffiliateFeeAmount(
           verifiedBps,
           swap.swapperName,
           effectiveSellAmount,
@@ -531,49 +522,6 @@ export class SwapsService {
     }
 
     return { feeUsd: totalFeeUsd * commissionRate, volumeUsd: sellAmountUsd }
-  }
-
-  private resolveFeeAssetPrice(swap: {
-    sellAsset: unknown
-    buyAsset: unknown
-    sellAmountCryptoBaseUnit: string
-    sellAmountUsd: string | null
-    buyAssetUsd: string | null
-    affiliateAssetUsd: string | null
-    affiliateFeeAssetId: string | null
-  }): string | null {
-    if (!swap.affiliateFeeAssetId) return null
-    const sellAssetObj = swap.sellAsset as Asset
-    const buyAssetObj = swap.buyAsset as Asset
-    if (swap.affiliateFeeAssetId === sellAssetObj.assetId && swap.sellAmountUsd) {
-      // Back-derive sell price from stored USD value.
-      const sellAmountPrecision = bnOrZero(swap.sellAmountCryptoBaseUnit).div(bnOrZero(10).pow(sellAssetObj.precision))
-      return sellAmountPrecision.isZero() ? null : bnOrZero(swap.sellAmountUsd).div(sellAmountPrecision).toFixed()
-    }
-    if (swap.affiliateFeeAssetId === buyAssetObj.assetId) {
-      return swap.buyAssetUsd
-    }
-    return swap.affiliateAssetUsd
-  }
-
-  private estimateAffiliateFeeAmount(
-    affiliateBps: number,
-    swapperName: string,
-    sellAmountCryptoBaseUnit: string,
-    expectedBuyAmountCryptoBaseUnit: string,
-  ): string {
-    const strategy = getSwapperFeeStrategy(swapperName)
-    const bpsMultiplier = affiliateBps / 10000
-
-    switch (strategy) {
-      case 'sell_asset':
-        return bnOrZero(sellAmountCryptoBaseUnit).times(bpsMultiplier).toFixed(0)
-      case 'buy_asset':
-        return bnOrZero(expectedBuyAmountCryptoBaseUnit).times(bpsMultiplier).toFixed(0)
-      case 'fixed_base':
-      default:
-        return bnOrZero(sellAmountCryptoBaseUnit).times(bpsMultiplier).toFixed(0)
-    }
   }
 
   async pollSwapStatus(swapId: string): Promise<SwapStatusResponse> {

--- a/apps/swap-service/src/swaps/swaps.service.ts
+++ b/apps/swap-service/src/swaps/swaps.service.ts
@@ -2,7 +2,12 @@ import { Injectable, Logger } from '@nestjs/common'
 import { Prisma, Swap } from '@prisma/client'
 
 import { CreateSwapDto, SwapStatusResponse, UpdateSwapStatusDto } from '@shapeshift/shared-types'
-import { hashAccountId, NotificationsServiceClient, UserServiceClient } from '@shapeshift/shared-utils'
+import {
+  baseUnitToPrecision,
+  hashAccountId,
+  NotificationsServiceClient,
+  UserServiceClient,
+} from '@shapeshift/shared-utils'
 import { ChainId } from '@shapeshiftoss/caip'
 import { bnOrZero } from '@shapeshiftoss/chain-adapters'
 import type { Swap as SwapperSwap, SwapperSpecificMetadata } from '@shapeshiftoss/swapper'
@@ -25,20 +30,7 @@ import { getNextCursor, swapCursorArgs } from '../utils/pagination'
 import { getAssetPriceUsd } from '../utils/pricing'
 import { SwapVerificationService } from '../verification/swap-verification.service'
 
-type AffiliateVerificationDetails = {
-  affiliateBps?: number
-  affiliateAddress?: string
-  verifiedSellAmountCryptoBaseUnit?: string
-  hasAffiliate?: boolean
-}
-
-export type SwapWithAssets = Omit<Swap, 'sellAsset' | 'buyAsset'> & {
-  sellAsset: Asset
-  buyAsset: Asset
-}
-
-const baseUnitToPrecision = (baseUnit: string, precision: number): string =>
-  bnOrZero(baseUnit).div(bnOrZero(10).pow(precision)).toFixed()
+import type { AffiliateVerificationDetails, PaginationOptions, SwapWithAssets, UsdPrices } from './types'
 
 @Injectable()
 export class SwapsService {
@@ -65,64 +57,24 @@ export class SwapsService {
     this.userServiceClient = new UserServiceClient()
   }
 
-  async createSwap(data: CreateSwapDto) {
+  async createSwap(data: CreateSwapDto): Promise<Swap> {
     try {
-      const referralCode = data.userId ? await this.userServiceClient.getUserReferralCode(data.userId) : null
-
-      if (referralCode) {
-        this.logger.debug(`Found referral code ${referralCode} for user ${data.userId}`)
-      }
-
       const affiliateFeeAssetId = resolveAffiliateFeeAssetId(data.swapperName, data.sellAsset, data.buyAsset)
 
-      let sellAmountUsd: string | null = null
-      let buyAssetUsd: string | null = null
-      let affiliateAssetUsd: string | null = null
-      try {
-        const needsAffiliatePrice =
-          !!affiliateFeeAssetId &&
-          affiliateFeeAssetId !== data.sellAsset.assetId &&
-          affiliateFeeAssetId !== data.buyAsset.assetId
-        const [sellPrice, buyPrice, affiliatePrice] = await Promise.all([
-          getAssetPriceUsd(data.sellAsset),
-          getAssetPriceUsd(data.buyAsset),
-          needsAffiliatePrice
-            ? getAssetPriceUsd({ assetId: affiliateFeeAssetId } as Asset)
-            : Promise.resolve<number | null>(null),
-        ])
-        if (sellPrice) {
-          sellAmountUsd = bnOrZero(data.sellAmountCryptoBaseUnit)
-            .div(bnOrZero(10).pow(data.sellAsset.precision))
-            .times(sellPrice)
-            .toFixed(2)
-        }
-        if (buyPrice) buyAssetUsd = buyPrice.toString()
-        if (affiliatePrice) affiliateAssetUsd = affiliatePrice.toString()
-      } catch (err) {
-        this.logger.warn(`Failed to fetch creation-time USD prices for swap ${data.swapId}:`, err)
-      }
+      const [referralCode, prices, affiliateAddress] = await Promise.all([
+        this.getReferralCode(data.userId),
+        this.fetchUsdPrices(data, affiliateFeeAssetId),
+        this.resolveAffiliateAddress(data),
+      ])
 
-      let affiliateAddress = data.affiliateAddress || null
-      if (!affiliateAddress && data.partnerCode) {
-        try {
-          const affiliate = await this.prisma.affiliate.findFirst({
-            where: { partnerCode: data.partnerCode },
-            select: { receiveAddress: true, walletAddress: true },
-          })
-          if (affiliate) {
-            affiliateAddress = affiliate.receiveAddress ?? affiliate.walletAddress
-          }
-        } catch (error) {
-          this.logger.warn(`Failed to resolve partner code ${data.partnerCode}:`, error)
-        }
-      }
+      if (referralCode) this.logger.debug(`Found referral code ${referralCode} for user ${data.userId}`)
 
       const swap = await this.prisma.swap.create({
         data: {
           swapId: data.swapId,
           sellAsset: data.sellAsset,
           buyAsset: data.buyAsset,
-          sellTxHash: data.sellTxHash || null,
+          sellTxHash: data.sellTxHash ?? null,
           sellAmountCryptoBaseUnit: data.sellAmountCryptoBaseUnit,
           expectedBuyAmountCryptoBaseUnit: data.expectedBuyAmountCryptoBaseUnit,
           source: data.source,
@@ -130,31 +82,82 @@ export class SwapsService {
           sellAccountId: data.sellAccountId ? hashAccountId(data.sellAccountId) : 'api',
           buyAccountId: data.buyAccountId ? hashAccountId(data.buyAccountId) : null,
           receiveAddress: data.receiveAddress,
-          isStreaming: data.isStreaming || false,
-          metadata: (data.metadata || {}) as Prisma.InputJsonValue,
-          userId: data.userId || 'api',
+          isStreaming: data.isStreaming ?? false,
+          metadata: (data.metadata ?? {}) as Prisma.InputJsonValue,
+          userId: data.userId ?? 'api',
           referralCode,
-          sellAmountUsd,
-          buyAssetUsd,
-          affiliateAssetUsd,
+          sellAmountUsd: prices.sellAmountUsd,
+          buyAssetUsd: prices.buyAssetUsd,
+          affiliateAssetUsd: prices.affiliateAssetUsd,
           affiliateAddress,
           affiliateBps: data.affiliateBps ?? null,
-          origin: data.origin || null,
+          origin: data.origin ?? null,
           shapeshiftBps: SwapsService.API_BASE_BPS,
           affiliateFeeAssetId,
         },
       })
 
       this.logger.log(
-        `Swap created: ${swap.swapId}` +
-          `${referralCode ? ` with referral code ${referralCode}` : ''}` +
-          `${data.affiliateAddress ? ` with affiliate ${data.affiliateAddress}` : ''}` +
-          `${sellAmountUsd ? ` ($${sellAmountUsd})` : ''}`,
+        [
+          `Swap created: ${swap.swapId}`,
+          referralCode && `referral ${referralCode}`,
+          affiliateAddress && `affiliate ${affiliateAddress}`,
+          prices.sellAmountUsd && `$${prices.sellAmountUsd}`,
+        ]
+          .filter(Boolean)
+          .join(' | '),
       )
+
       return swap
     } catch (error) {
       this.logger.error('Failed to create swap', error)
       throw error
+    }
+  }
+
+  private async getReferralCode(userId: string | undefined): Promise<string | null> {
+    if (!userId) return null
+    return this.userServiceClient.getUserReferralCode(userId)
+  }
+
+  private async fetchUsdPrices(data: CreateSwapDto, affiliateFeeAssetId: string | null): Promise<UsdPrices> {
+    try {
+      const [sellAssetUsd, buyAssetUsd, affiliateAssetUsd] = await Promise.all([
+        getAssetPriceUsd(data.sellAsset.assetId),
+        getAssetPriceUsd(data.buyAsset.assetId),
+        affiliateFeeAssetId ? getAssetPriceUsd(affiliateFeeAssetId) : Promise.resolve<number | null>(null),
+      ])
+
+      const sellAmountUsd = sellAssetUsd
+        ? bnOrZero(baseUnitToPrecision(data.sellAmountCryptoBaseUnit, data.sellAsset.precision))
+            .times(sellAssetUsd)
+            .toFixed(2)
+        : null
+
+      return {
+        sellAmountUsd,
+        buyAssetUsd: buyAssetUsd?.toString() ?? null,
+        affiliateAssetUsd: affiliateAssetUsd?.toString() ?? null,
+      }
+    } catch (err) {
+      this.logger.warn(`Failed to fetch USD prices for swap ${data.swapId}:`, err)
+      return { sellAmountUsd: null, buyAssetUsd: null, affiliateAssetUsd: null }
+    }
+  }
+
+  private async resolveAffiliateAddress(data: CreateSwapDto): Promise<string | null> {
+    if (data.affiliateAddress) return data.affiliateAddress
+    if (!data.partnerCode) return null
+
+    try {
+      const affiliate = await this.prisma.affiliate.findFirst({
+        where: { partnerCode: data.partnerCode },
+        select: { receiveAddress: true, walletAddress: true },
+      })
+      return affiliate?.receiveAddress ?? affiliate?.walletAddress ?? null
+    } catch (error) {
+      this.logger.warn(`Failed to resolve affiliate address for partner code ${data.partnerCode}:`, error)
+      return null
     }
   }
 
@@ -250,22 +253,22 @@ export class SwapsService {
     }
   }
 
-  async getSwapsByUser(userId: string, { limit = 50, cursor }: { limit?: number; cursor?: string } = {}) {
-    return this.paginateSwaps({ userId }, { limit, cursor })
+  async getSwapsByUser(userId: string, options: PaginationOptions = {}) {
+    return this.paginateSwaps({ userId }, options)
   }
 
-  async getSwapsByAccountId(accountId: string, { limit = 50, cursor }: { limit?: number; cursor?: string } = {}) {
+  async getSwapsByAccountId(accountId: string, options: PaginationOptions = {}) {
     const hashedAccountId = hashAccountId(accountId)
 
     return this.paginateSwaps(
       {
         OR: [{ sellAccountId: hashedAccountId }, { buyAccountId: hashedAccountId }],
       },
-      { limit, cursor },
+      options,
     )
   }
 
-  private async paginateSwaps(where: Prisma.SwapWhereInput, { limit, cursor }: { limit: number; cursor?: string }) {
+  private async paginateSwaps(where: Prisma.SwapWhereInput, { limit = 50, cursor }: PaginationOptions) {
     const items = await this.prisma.swap.findMany({ where, ...swapCursorArgs(limit, cursor) })
 
     return { items, nextCursor: getNextCursor(items, limit) }

--- a/apps/swap-service/src/swaps/swaps.service.ts
+++ b/apps/swap-service/src/swaps/swaps.service.ts
@@ -1,13 +1,11 @@
 import { Injectable, Logger } from '@nestjs/common'
 import { Prisma } from '@prisma/client'
 
-import { CreateSwapDto, SwapStatusResponse, UpdateSwapStatusDto } from '@shapeshift/shared-types'
+import { CreateSwapDto, Fees, SwapStatusResponse, UpdateSwapStatusDto } from '@shapeshift/shared-types'
 import { hashAccountId, NotificationsServiceClient, UserServiceClient } from '@shapeshift/shared-utils'
 import { ChainId } from '@shapeshiftoss/caip'
-import { bnOrZero } from '@shapeshiftoss/chain-adapters'
 import type { Swap as SwapperSwap } from '@shapeshiftoss/swapper'
 import { SwapperName, swappers } from '@shapeshiftoss/swapper'
-import { Asset } from '@shapeshiftoss/types'
 import { TxStatus } from '@shapeshiftoss/unchained-client'
 
 import { CosmosSdkChainAdapterService } from '../lib/chain-adapters/cosmos-sdk.service'
@@ -24,17 +22,9 @@ import { resolveAffiliateFeeAssetId } from '../utils/affiliateFeeAsset'
 import { getNextCursor, swapCursorArgs } from '../utils/pagination'
 import { SwapVerificationService } from '../verification/swap-verification.service'
 
-import type { AffiliateVerificationDetails, PaginatedSwaps, Swap } from './types'
+import type { AggregateFeesParams, FeeTotals, PaginatedSwaps, Swap } from './types'
 import { PaginationQueryDto } from './types'
-import {
-  buildStatusNotification,
-  estimateAffiliateFeeAmount,
-  fetchUsdPrices,
-  getAffiliateCommissionRate,
-  resolveFeeAssetPrice,
-  resolveSwapSellAmountUsd,
-  toSwap,
-} from './utils'
+import { buildStatusNotification, calculateFeeForSwap, fetchUsdPrices, getAffiliateFeeRate, toSwap } from './utils'
 
 const logger = new Logger('SwapsService')
 
@@ -44,6 +34,7 @@ export class SwapsService {
   private readonly userServiceClient: UserServiceClient
 
   private static readonly API_BASE_BPS = 10
+  private static readonly REFERRER_FEE_RATE = 0.1
 
   constructor(
     private prisma: PrismaService,
@@ -211,245 +202,117 @@ export class SwapsService {
 
   async getPendingSwaps(): Promise<Swap[]> {
     const swaps = await this.prisma.swap.findMany({
-      where: {
-        status: {
-          in: ['IDLE', 'PENDING'],
-        },
-        sellTxHash: { not: null },
-      },
+      where: { status: { in: ['IDLE', 'PENDING'] }, sellTxHash: { not: null } },
     })
 
     return swaps.map(toSwap)
   }
 
-  async calculateReferralFees(referralCode: string, startDate?: Date, endDate?: Date) {
+  async calculateReferralFees(referralCode: string, startDate?: Date, endDate?: Date): Promise<Fees> {
     logger.log(
       `Calculating referral fees for code: ${referralCode}, period: ${startDate?.toISOString()} - ${endDate?.toISOString()}`,
     )
 
-    const periodWhereClause: Prisma.SwapWhereInput = {
-      referralCode,
-      isAffiliateVerified: true,
-      status: 'SUCCESS',
-    }
-
-    if (startDate && endDate) {
-      periodWhereClause.createdAt = { gte: startDate, lte: endDate }
-    }
-
-    const referralSwapSelect = {
-      swapId: true,
-      sellAmountUsd: true,
-      affiliateVerificationDetails: true,
-      createdAt: true,
-    } as const
-
-    const periodSwaps = await this.prisma.swap.findMany({
-      where: periodWhereClause,
-      select: referralSwapSelect,
-    })
-
-    const allTimeSwaps = await this.prisma.swap.findMany({
-      where: {
-        referralCode,
-        isAffiliateVerified: true,
-        status: 'SUCCESS',
+    const fees = await this.aggregateFees({
+      baseWhere: { referralCode, isAffiliateVerified: true, status: 'SUCCESS', origin: 'web' },
+      startDate,
+      endDate,
+      calcFee: (swap) => {
+        const fee = calculateFeeForSwap(swap)
+        if (!fee) return null
+        return { feeUsd: fee.feeUsd * SwapsService.REFERRER_FEE_RATE, volumeUsd: fee.volumeUsd }
       },
-      select: referralSwapSelect,
     })
 
     logger.log(
-      `Found ${periodSwaps.length} swaps for period, ${allTimeSwaps.length} swaps all-time for referral code ${referralCode}`,
+      `Referral fees for ${referralCode}\n` +
+        `  period:   ${fees.periodCount} swaps, $${fees.periodVolumeUsd.toFixed(2)} volume, $${fees.periodFeesUsd.toFixed(2)} fee\n` +
+        `  all-time: ${fees.allTimeCount} swaps, $${fees.allTimeFeesUsd.toFixed(2)} fee`,
     )
 
-    const sumFees = (swaps: typeof periodSwaps) => {
-      let totalFeesUsd = 0
-      let totalVolumeUsd = 0
-      for (const swap of swaps) {
-        const sellAmountUsd = resolveSwapSellAmountUsd(swap)
-        if (sellAmountUsd === null) continue
-        totalVolumeUsd += sellAmountUsd
-        const details = swap.affiliateVerificationDetails as AffiliateVerificationDetails | null
-        const bps = details?.affiliateBps
-        if (bps && sellAmountUsd > 0) {
-          totalFeesUsd += (sellAmountUsd * bps) / 10000
-        }
+    return {
+      swapCount: fees.periodCount,
+      periodVolumeUsd: fees.periodVolumeUsd.toFixed(2),
+      periodFeeUsd: fees.periodFeesUsd.toFixed(2),
+      allTimeFeeUsd: fees.allTimeFeesUsd.toFixed(2),
+      periodStart: startDate?.toISOString(),
+      periodEnd: endDate?.toISOString(),
+    }
+  }
+
+  async calculateAffiliateFees(affiliateAddress: string, startDate?: Date, endDate?: Date): Promise<Fees> {
+    logger.log(
+      `Calculating affiliate fees for address: ${affiliateAddress}, period: ${startDate?.toISOString()} - ${endDate?.toISOString()}`,
+    )
+
+    const fees = await this.aggregateFees({
+      baseWhere: { affiliateAddress, isAffiliateVerified: true, status: 'SUCCESS', origin: 'api' },
+      startDate,
+      endDate,
+      calcFee: (swap) => {
+        const fee = calculateFeeForSwap(swap)
+        if (!fee) return null
+        const rate = getAffiliateFeeRate(fee.verifiedBps, swap.shapeshiftBps)
+        return { feeUsd: fee.feeUsd * rate, volumeUsd: fee.volumeUsd }
+      },
+    })
+
+    logger.log(
+      `Affiliate fees for ${affiliateAddress}\n` +
+        `  period:   ${fees.periodCount} swaps, $${fees.periodVolumeUsd.toFixed(2)} volume, $${fees.periodFeesUsd.toFixed(2)} fee\n` +
+        `  all-time: ${fees.allTimeCount} swaps, $${fees.allTimeFeesUsd.toFixed(2)} fee`,
+    )
+
+    return {
+      swapCount: fees.periodCount,
+      periodVolumeUsd: fees.periodVolumeUsd.toFixed(2),
+      periodFeeUsd: fees.periodFeesUsd.toFixed(2),
+      allTimeFeeUsd: fees.allTimeFeesUsd.toFixed(2),
+      periodStart: startDate?.toISOString(),
+      periodEnd: endDate?.toISOString(),
+    }
+  }
+
+  private async aggregateFees(params: AggregateFeesParams): Promise<FeeTotals> {
+    const { baseWhere, startDate, endDate, calcFee } = params
+
+    const rows = await this.prisma.swap.findMany({ where: baseWhere })
+
+    const isInPeriod = (createdAt: Date): boolean => {
+      if (startDate && createdAt < startDate) return false
+      if (endDate && createdAt > endDate) return false
+      return true
+    }
+
+    let periodCount = 0
+    let periodVolumeUsd = 0
+    let periodFeesUsd = 0
+    let allTimeCount = 0
+    let allTimeFeesUsd = 0
+
+    for (const row of rows) {
+      const swap = toSwap(row)
+
+      const result = calcFee(swap)
+      if (!result) continue
+
+      allTimeCount += 1
+      allTimeFeesUsd += result.feeUsd
+
+      if (isInPeriod(swap.createdAt)) {
+        periodCount += 1
+        periodVolumeUsd += result.volumeUsd
+        periodFeesUsd += result.feeUsd
       }
-      return { totalFeesUsd, totalVolumeUsd }
     }
-
-    const period = sumFees(periodSwaps)
-    const allTime = sumFees(allTimeSwaps)
-
-    // Referrer receives 10% of affiliate fees collected.
-    const periodReferrerCommissionUsd = period.totalFeesUsd * 0.1
-    const allTimeReferrerCommissionUsd = allTime.totalFeesUsd * 0.1
-
-    logger.log(
-      `Referral fee calculation for ${referralCode}: ` +
-        `Period: ${periodSwaps.length} swaps, $${period.totalVolumeUsd.toFixed(2)} volume, $${periodReferrerCommissionUsd.toFixed(2)} commission | ` +
-        `All-time: ${allTimeSwaps.length} swaps, $${allTimeReferrerCommissionUsd.toFixed(2)} total commission`,
-    )
 
     return {
-      referralCode,
-      swapCount: periodSwaps.length,
-      totalSwapVolumeUsd: period.totalVolumeUsd.toFixed(2),
-      totalFeesCollectedUsd: allTimeReferrerCommissionUsd.toFixed(2),
-      referrerCommissionUsd: periodReferrerCommissionUsd.toFixed(2),
-      periodStart: startDate?.toISOString(),
-      periodEnd: endDate?.toISOString(),
+      periodCount,
+      periodVolumeUsd,
+      periodFeesUsd,
+      allTimeCount,
+      allTimeFeesUsd,
     }
-  }
-
-  async calculateAffiliateFees(affiliateAddress: string, startDate?: Date, endDate?: Date) {
-    const normalizedAddress = affiliateAddress.toLowerCase()
-
-    logger.log(
-      `Calculating affiliate fees for address: ${normalizedAddress}, period: ${startDate?.toISOString()} - ${endDate?.toISOString()}`,
-    )
-
-    const periodWhereClause: Prisma.SwapWhereInput = {
-      affiliateAddress: normalizedAddress,
-      isAffiliateVerified: true,
-      status: 'SUCCESS',
-    }
-
-    if (startDate && endDate) {
-      periodWhereClause.createdAt = { gte: startDate, lte: endDate }
-    }
-
-    const swapSelect = {
-      swapId: true,
-      swapperName: true,
-      sellAsset: true,
-      buyAsset: true,
-      sellAmountCryptoBaseUnit: true,
-      expectedBuyAmountCryptoBaseUnit: true,
-      sellAmountUsd: true,
-      buyAssetUsd: true,
-      affiliateAssetUsd: true,
-      affiliateBps: true,
-      origin: true,
-      affiliateFeeAssetId: true,
-      actualAffiliateFeeAmountCryptoBaseUnit: true,
-      affiliateVerificationDetails: true,
-      createdAt: true,
-      shapeshiftBps: true,
-    } as const
-
-    const periodSwaps = await this.prisma.swap.findMany({
-      where: periodWhereClause,
-      select: swapSelect,
-    })
-
-    const allTimeSwaps = await this.prisma.swap.findMany({
-      where: {
-        affiliateAddress: normalizedAddress,
-        isAffiliateVerified: true,
-        status: 'SUCCESS',
-      },
-      select: swapSelect,
-    })
-
-    logger.log(
-      `Found ${periodSwaps.length} swaps for period, ${allTimeSwaps.length} swaps all-time for affiliate ${normalizedAddress}`,
-    )
-
-    let periodCommissionUsd = 0
-    let totalSwapVolumeUsd = 0
-    for (const swap of periodSwaps) {
-      const { feeUsd, volumeUsd } = this.calculateFeeForSwap(swap)
-      totalSwapVolumeUsd += volumeUsd
-      periodCommissionUsd += feeUsd
-    }
-
-    let allTimeCommissionUsd = 0
-    for (const swap of allTimeSwaps) {
-      const { feeUsd } = this.calculateFeeForSwap(swap)
-      allTimeCommissionUsd += feeUsd
-    }
-
-    logger.log(
-      `Affiliate fee calculation for ${normalizedAddress}: ` +
-        `Period: ${periodSwaps.length} swaps, $${totalSwapVolumeUsd.toFixed(2)} volume, $${periodCommissionUsd.toFixed(2)} commission | ` +
-        `All-time: ${allTimeSwaps.length} swaps, $${allTimeCommissionUsd.toFixed(2)} total commission`,
-    )
-
-    return {
-      affiliateAddress: normalizedAddress,
-      swapCount: periodSwaps.length,
-      totalSwapVolumeUsd: totalSwapVolumeUsd.toFixed(2),
-      totalFeesCollectedUsd: allTimeCommissionUsd.toFixed(2),
-      referrerCommissionUsd: periodCommissionUsd.toFixed(2),
-      periodStart: startDate?.toISOString(),
-      periodEnd: endDate?.toISOString(),
-    }
-  }
-
-  private calculateFeeForSwap(swap: {
-    swapId: string
-    swapperName: string
-    sellAsset: unknown
-    buyAsset: unknown
-    sellAmountCryptoBaseUnit: string
-    expectedBuyAmountCryptoBaseUnit: string
-    sellAmountUsd: string | null
-    buyAssetUsd: string | null
-    affiliateAssetUsd: string | null
-    affiliateBps: number | null
-    origin: string | null
-    affiliateFeeAssetId: string | null
-    actualAffiliateFeeAmountCryptoBaseUnit: string | null
-    affiliateVerificationDetails: unknown
-    shapeshiftBps: number
-  }): { feeUsd: number; volumeUsd: number } {
-    const sellAmountUsd = resolveSwapSellAmountUsd(swap)
-    if (sellAmountUsd === null) return { feeUsd: 0, volumeUsd: 0 }
-
-    const verificationDetails = swap.affiliateVerificationDetails as AffiliateVerificationDetails | null
-    const verifiedBps = verificationDetails?.affiliateBps ?? swap.affiliateBps ?? undefined
-
-    if (!verifiedBps || sellAmountUsd <= 0) {
-      return { feeUsd: 0, volumeUsd: sellAmountUsd }
-    }
-
-    const commissionRate = getAffiliateCommissionRate(swap.origin, verifiedBps, swap.shapeshiftBps)
-
-    const verifiedSell = verificationDetails?.verifiedSellAmountCryptoBaseUnit
-    const effectiveSellAmount = verifiedSell
-      ? bnOrZero(verifiedSell).lt(bnOrZero(swap.sellAmountCryptoBaseUnit))
-        ? verifiedSell
-        : swap.sellAmountCryptoBaseUnit
-      : swap.sellAmountCryptoBaseUnit
-
-    let totalFeeUsd: number
-    const feeAssetId = swap.affiliateFeeAssetId
-    const feeAssetPrice = resolveFeeAssetPrice(swap)
-
-    if (feeAssetId && feeAssetPrice) {
-      const sellAssetObj = swap.sellAsset as Asset
-      const buyAssetObj = swap.buyAsset as Asset
-      const feeAmountBaseUnit =
-        swap.actualAffiliateFeeAmountCryptoBaseUnit ??
-        estimateAffiliateFeeAmount(
-          verifiedBps,
-          swap.swapperName,
-          effectiveSellAmount,
-          swap.expectedBuyAmountCryptoBaseUnit,
-        )
-      const feeAssetPrecision =
-        feeAssetId === sellAssetObj.assetId
-          ? sellAssetObj.precision
-          : feeAssetId === buyAssetObj.assetId
-            ? buyAssetObj.precision
-            : sellAssetObj.precision
-      totalFeeUsd = bnOrZero(feeAmountBaseUnit).div(bnOrZero(10).pow(feeAssetPrecision)).times(feeAssetPrice).toNumber()
-    } else {
-      totalFeeUsd = (sellAmountUsd * verifiedBps) / 10000
-    }
-
-    return { feeUsd: totalFeeUsd * commissionRate, volumeUsd: sellAmountUsd }
   }
 
   async pollSwapStatus(swapId: string): Promise<SwapStatusResponse> {
@@ -629,5 +492,4 @@ export class SwapsService {
       }
     }
   }
-
 }

--- a/apps/swap-service/src/swaps/swaps.service.ts
+++ b/apps/swap-service/src/swaps/swaps.service.ts
@@ -27,15 +27,16 @@ import { UtxoChainAdapterService } from '../lib/chain-adapters/utxo.service'
 import { PrismaService } from '../prisma/prisma.service'
 import { resolveAffiliateFeeAssetId } from '../utils/affiliateFeeAsset'
 import { getNextCursor, swapCursorArgs } from '../utils/pagination'
-import { getAssetPriceUsd } from '../utils/pricing'
 import { SwapVerificationService } from '../verification/swap-verification.service'
 
-import type { AffiliateVerificationDetails, PaginationOptions, Swap, UsdPrices } from './types'
+import type { AffiliateVerificationDetails, PaginationOptions, Swap } from './types'
 import {
   estimateAffiliateFeeAmount,
+  fetchUsdPrices,
   formatAmount,
   getAffiliateCommissionRate,
   resolveFeeAssetPrice,
+  resolveSwapSellAmountUsd,
   toSwap,
 } from './utils'
 
@@ -70,39 +71,41 @@ export class SwapsService {
 
       const [referralCode, prices, affiliateAddress] = await Promise.all([
         this.getReferralCode(data.userId),
-        this.fetchUsdPrices(data, affiliateFeeAssetId),
+        fetchUsdPrices(data, affiliateFeeAssetId),
         this.resolveAffiliateAddress(data),
       ])
 
       if (referralCode) this.logger.debug(`Found referral code ${referralCode} for user ${data.userId}`)
 
-      const swap = await this.prisma.swap.create({
-        data: {
-          swapId: data.swapId,
-          sellAsset: data.sellAsset,
-          buyAsset: data.buyAsset,
-          sellTxHash: data.sellTxHash ?? null,
-          sellAmountCryptoBaseUnit: data.sellAmountCryptoBaseUnit,
-          expectedBuyAmountCryptoBaseUnit: data.expectedBuyAmountCryptoBaseUnit,
-          source: data.source,
-          swapperName: data.swapperName,
-          sellAccountId: data.sellAccountId ? hashAccountId(data.sellAccountId) : 'api',
-          buyAccountId: data.buyAccountId ? hashAccountId(data.buyAccountId) : null,
-          receiveAddress: data.receiveAddress,
-          isStreaming: data.isStreaming ?? false,
-          metadata: (data.metadata ?? {}) as Prisma.InputJsonValue,
-          userId: data.userId ?? 'api',
-          referralCode,
-          sellAmountUsd: prices.sellAmountUsd,
-          buyAssetUsd: prices.buyAssetUsd,
-          affiliateAssetUsd: prices.affiliateAssetUsd,
-          affiliateAddress,
-          affiliateBps: data.affiliateBps ?? null,
-          origin: data.origin ?? null,
-          shapeshiftBps: SwapsService.API_BASE_BPS,
-          affiliateFeeAssetId,
-        },
-      })
+      const swap = toSwap(
+        await this.prisma.swap.create({
+          data: {
+            swapId: data.swapId,
+            sellAsset: data.sellAsset,
+            buyAsset: data.buyAsset,
+            sellTxHash: data.sellTxHash ?? null,
+            sellAmountCryptoBaseUnit: data.sellAmountCryptoBaseUnit,
+            expectedBuyAmountCryptoBaseUnit: data.expectedBuyAmountCryptoBaseUnit,
+            source: data.source,
+            swapperName: data.swapperName,
+            sellAccountId: data.sellAccountId ? hashAccountId(data.sellAccountId) : 'api',
+            buyAccountId: data.buyAccountId ? hashAccountId(data.buyAccountId) : null,
+            receiveAddress: data.receiveAddress,
+            isStreaming: data.isStreaming ?? false,
+            metadata: (data.metadata ?? {}) as Prisma.InputJsonValue,
+            userId: data.userId ?? 'api',
+            referralCode,
+            sellAmountUsd: prices.sellAmountUsd,
+            buyAssetUsd: prices.buyAssetUsd,
+            affiliateAssetUsd: prices.affiliateAssetUsd,
+            affiliateAddress,
+            affiliateBps: data.affiliateBps ?? null,
+            origin: data.origin ?? null,
+            shapeshiftBps: SwapsService.API_BASE_BPS,
+            affiliateFeeAssetId,
+          },
+        }),
+      )
 
       this.logger.log(
         [
@@ -115,7 +118,7 @@ export class SwapsService {
           .join(' | '),
       )
 
-      return toSwap(swap)
+      return swap
     } catch (error) {
       this.logger.error('Failed to create swap', error)
       throw error
@@ -125,31 +128,6 @@ export class SwapsService {
   private async getReferralCode(userId: string | undefined): Promise<string | null> {
     if (!userId) return null
     return this.userServiceClient.getUserReferralCode(userId)
-  }
-
-  private async fetchUsdPrices(data: CreateSwapDto, affiliateFeeAssetId: string | null): Promise<UsdPrices> {
-    try {
-      const [sellAssetUsd, buyAssetUsd, affiliateAssetUsd] = await Promise.all([
-        getAssetPriceUsd(data.sellAsset.assetId),
-        getAssetPriceUsd(data.buyAsset.assetId),
-        affiliateFeeAssetId ? getAssetPriceUsd(affiliateFeeAssetId) : Promise.resolve<number | null>(null),
-      ])
-
-      const sellAmountUsd = sellAssetUsd
-        ? bnOrZero(baseUnitToPrecision(data.sellAmountCryptoBaseUnit, data.sellAsset.precision))
-            .times(sellAssetUsd)
-            .toFixed(2)
-        : null
-
-      return {
-        sellAmountUsd,
-        buyAssetUsd: buyAssetUsd?.toString() ?? null,
-        affiliateAssetUsd: affiliateAssetUsd?.toString() ?? null,
-      }
-    } catch (err) {
-      this.logger.warn(`Failed to fetch USD prices for swap ${data.swapId}:`, err)
-      return { sellAmountUsd: null, buyAssetUsd: null, affiliateAssetUsd: null }
-    }
   }
 
   private async resolveAffiliateAddress(data: CreateSwapDto): Promise<string | null> {
@@ -330,7 +308,7 @@ export class SwapsService {
       let totalFeesUsd = 0
       let totalVolumeUsd = 0
       for (const swap of swaps) {
-        const sellAmountUsd = this.resolveSwapSellAmountUsd(swap)
+        const sellAmountUsd = resolveSwapSellAmountUsd(swap)
         if (sellAmountUsd === null) continue
         totalVolumeUsd += sellAmountUsd
         const details = swap.affiliateVerificationDetails as AffiliateVerificationDetails | null
@@ -364,14 +342,6 @@ export class SwapsService {
       periodStart: startDate?.toISOString(),
       periodEnd: endDate?.toISOString(),
     }
-  }
-
-  private resolveSwapSellAmountUsd(swap: { swapId: string; sellAmountUsd: string | null }): number | null {
-    if (!swap.sellAmountUsd) {
-      this.logger.warn(`Missing sellAmountUsd for swap ${swap.swapId}, skipping`)
-      return null
-    }
-    return parseFloat(swap.sellAmountUsd)
   }
 
   async calculateAffiliateFees(affiliateAddress: string, startDate?: Date, endDate?: Date) {
@@ -476,7 +446,7 @@ export class SwapsService {
     affiliateVerificationDetails: unknown
     shapeshiftBps: number
   }): { feeUsd: number; volumeUsd: number } {
-    const sellAmountUsd = this.resolveSwapSellAmountUsd(swap)
+    const sellAmountUsd = resolveSwapSellAmountUsd(swap)
     if (sellAmountUsd === null) return { feeUsd: 0, volumeUsd: 0 }
 
     const verificationDetails = swap.affiliateVerificationDetails as AffiliateVerificationDetails | null

--- a/apps/swap-service/src/swaps/swaps.service.ts
+++ b/apps/swap-service/src/swaps/swaps.service.ts
@@ -1,4 +1,10 @@
-import { BadRequestException, Injectable, InternalServerErrorException, Logger, NotFoundException } from '@nestjs/common'
+import {
+  BadRequestException,
+  Injectable,
+  InternalServerErrorException,
+  Logger,
+  NotFoundException,
+} from '@nestjs/common'
 import { Prisma } from '@prisma/client'
 
 import { CreateSwapDto, Fees, SwapStatusResponse, UpdateSwapStatusDto } from '@shapeshift/shared-types'
@@ -178,8 +184,8 @@ export class SwapsService {
 
       try {
         await this.sendStatusUpdateNotification(swap)
-      } catch (notifError) {
-        logger.error(`Failed to send notification for swap ${swap.swapId}:`, notifError)
+      } catch {
+        logger.error(`Failed to send notification for swap ${swap.swapId}`)
       }
 
       logger.log(`Swap status updated: ${swap.swapId} -> ${swap.status}`)
@@ -192,6 +198,8 @@ export class SwapsService {
   }
 
   private async sendStatusUpdateNotification(swap: Swap) {
+    if (swap.userId === 'api') return
+
     const notification = buildStatusNotification(swap)
     if (!notification) return
 

--- a/apps/swap-service/src/swaps/swaps.service.ts
+++ b/apps/swap-service/src/swaps/swaps.service.ts
@@ -1,4 +1,4 @@
-import { BadRequestException, Injectable, Logger, NotFoundException } from '@nestjs/common'
+import { BadRequestException, Injectable, InternalServerErrorException, Logger, NotFoundException } from '@nestjs/common'
 import { Prisma } from '@prisma/client'
 
 import { CreateSwapDto, Fees, SwapStatusResponse, UpdateSwapStatusDto } from '@shapeshift/shared-types'
@@ -349,7 +349,7 @@ export class SwapsService {
     const swap = toSwap(prismaSwap)
 
     const swapper = swappers[swap.swapperName as SwapperName]
-    if (!swapper) throw new NotFoundException(`Swapper not found: ${swap.swapperName}`)
+    if (!swapper) throw new InternalServerErrorException(`Swapper not registered: ${swap.swapperName}`)
 
     if (!swap.sellTxHash) throw new BadRequestException('Sell tx hash is required')
 

--- a/apps/swap-service/src/swaps/swaps.service.ts
+++ b/apps/swap-service/src/swaps/swaps.service.ts
@@ -1,5 +1,5 @@
 import { Injectable, Logger } from '@nestjs/common'
-import { Prisma, Swap } from '@prisma/client'
+import { Prisma } from '@prisma/client'
 
 import { CreateSwapDto, SwapStatusResponse, UpdateSwapStatusDto } from '@shapeshift/shared-types'
 import {
@@ -10,7 +10,7 @@ import {
 } from '@shapeshift/shared-utils'
 import { ChainId } from '@shapeshiftoss/caip'
 import { bnOrZero } from '@shapeshiftoss/chain-adapters'
-import type { Swap as SwapperSwap, SwapperSpecificMetadata } from '@shapeshiftoss/swapper'
+import type { Swap as SwapperSwap } from '@shapeshiftoss/swapper'
 import { SwapperName, swappers } from '@shapeshiftoss/swapper'
 import { Asset } from '@shapeshiftoss/types'
 import { TxStatus } from '@shapeshiftoss/unchained-client'
@@ -30,7 +30,8 @@ import { getNextCursor, swapCursorArgs } from '../utils/pagination'
 import { getAssetPriceUsd } from '../utils/pricing'
 import { SwapVerificationService } from '../verification/swap-verification.service'
 
-import type { AffiliateVerificationDetails, PaginationOptions, SwapWithAssets, UsdPrices } from './types'
+import { toSwap } from './types'
+import type { AffiliateVerificationDetails, PaginationOptions, Swap, UsdPrices } from './types'
 
 @Injectable()
 export class SwapsService {
@@ -108,7 +109,7 @@ export class SwapsService {
           .join(' | '),
       )
 
-      return swap
+      return toSwap(swap)
     } catch (error) {
       this.logger.error('Failed to create swap', error)
       throw error
@@ -161,32 +162,31 @@ export class SwapsService {
     }
   }
 
-  async updateSwapStatus(data: UpdateSwapStatusDto): Promise<SwapWithAssets> {
+  async updateSwapStatus(data: UpdateSwapStatusDto): Promise<Swap> {
     try {
-      const swap = await this.prisma.swap.update({
-        where: { swapId: data.swapId },
-        data: {
-          status: data.status,
-          sellTxHash: data.sellTxHash,
-          buyTxHash: data.buyTxHash,
-          txLink: data.txLink,
-          statusMessage: data.statusMessage,
-          actualBuyAmountCryptoBaseUnit: data.actualBuyAmountCryptoBaseUnit,
-        },
-      })
+      const swap = toSwap(
+        await this.prisma.swap.update({
+          where: { swapId: data.swapId },
+          data: {
+            status: data.status,
+            sellTxHash: data.sellTxHash,
+            buyTxHash: data.buyTxHash,
+            txLink: data.txLink,
+            statusMessage: data.statusMessage,
+            actualBuyAmountCryptoBaseUnit: data.actualBuyAmountCryptoBaseUnit,
+          },
+        }),
+      )
 
       try {
         await this.sendStatusUpdateNotification(swap)
       } catch (notifError) {
-        this.logger.error(`Failed to send notification for swap ${data.swapId}:`, notifError)
+        this.logger.error(`Failed to send notification for swap ${swap.swapId}:`, notifError)
       }
 
-      this.logger.log(`Swap status updated: ${swap.swapId} -> ${data.status}`)
-      return {
-        ...swap,
-        sellAsset: swap.sellAsset as Asset,
-        buyAsset: swap.buyAsset as Asset,
-      }
+      this.logger.log(`Swap status updated: ${swap.swapId} -> ${swap.status}`)
+
+      return swap
     } catch (error) {
       this.logger.error('Failed to update swap status', error)
       throw error
@@ -216,8 +216,7 @@ export class SwapsService {
     let body: string
     let type: 'SWAP_STATUS_UPDATE' | 'SWAP_COMPLETED' | 'SWAP_FAILED'
 
-    const sellAsset = swap.sellAsset as Asset
-    const buyAsset = swap.buyAsset as Asset
+    const { sellAsset, buyAsset } = swap
 
     switch (swap.status) {
       case 'SUCCESS': {
@@ -274,7 +273,7 @@ export class SwapsService {
     return { items, nextCursor: getNextCursor(items, limit) }
   }
 
-  async getPendingSwaps() {
+  async getPendingSwaps(): Promise<Swap[]> {
     const swaps = await this.prisma.swap.findMany({
       where: {
         status: {
@@ -284,11 +283,7 @@ export class SwapsService {
       },
     })
 
-    return swaps.map((swap) => ({
-      ...swap,
-      sellAsset: swap.sellAsset,
-      buyAsset: swap.buyAsset,
-    }))
+    return swaps.map(toSwap)
   }
 
   async calculateReferralFees(referralCode: string, startDate?: Date, endDate?: Date) {
@@ -585,15 +580,15 @@ export class SwapsService {
     try {
       this.logger.log(`Polling status for swap: ${swapId}`)
 
-      const swap = await this.prisma.swap.findUnique({
+      const rawSwap = await this.prisma.swap.findUnique({
         where: { swapId },
       })
 
-      if (!swap) {
+      if (!rawSwap) {
         throw new Error(`Swap not found: ${swapId}`)
       }
 
-      const sellAsset = swap.sellAsset as Asset
+      const swap = toSwap(rawSwap)
 
       const swapper = swappers[swap.swapperName as SwapperName]
 
@@ -607,7 +602,7 @@ export class SwapsService {
 
       const status = await swapper.checkTradeStatus({
         txHash: swap.sellTxHash ?? '',
-        chainId: sellAsset.chainId,
+        chainId: swap.sellAsset.chainId,
         address: swap.sellAccountId,
         swap: {
           ...swap,
@@ -615,7 +610,7 @@ export class SwapsService {
           createdAt: swap.createdAt.getTime(),
           updatedAt: swap.updatedAt.getTime(),
         } as unknown as SwapperSwap,
-        stepIndex: (swap.metadata as SwapperSpecificMetadata).stepIndex,
+        stepIndex: swap.metadata.stepIndex,
         config: {
           VITE_UNCHAINED_THORCHAIN_HTTP_URL: process.env.VITE_UNCHAINED_THORCHAIN_HTTP_URL || '',
           VITE_UNCHAINED_MAYACHAIN_HTTP_URL: process.env.VITE_UNCHAINED_MAYACHAIN_HTTP_URL || '',
@@ -699,7 +694,7 @@ export class SwapsService {
           receiveAddress: swap.receiveAddress,
           expectedBuyAmountCryptoBaseUnit: swap.expectedBuyAmountCryptoBaseUnit,
           createdAt: swap.createdAt.getTime(),
-          sellAssetPrecision: sellAsset.precision,
+          sellAssetPrecision: swap.sellAsset.precision,
           affiliateBps: swap.affiliateBps,
           affiliateAddress: swap.affiliateAddress,
           integratorFeeRecipient: swap.affiliateAddress,
@@ -709,7 +704,7 @@ export class SwapsService {
         const verificationResult = await this.swapVerificationService.verifySwapAffiliate(
           swapId,
           swap.swapperName,
-          sellAsset.chainId,
+          swap.sellAsset.chainId,
           swap.sellTxHash || undefined,
           enrichedMetadata,
         )

--- a/apps/swap-service/src/swaps/swaps.service.ts
+++ b/apps/swap-service/src/swaps/swaps.service.ts
@@ -1,10 +1,8 @@
-import { Injectable, Logger } from '@nestjs/common'
+import { BadRequestException, Injectable, Logger, NotFoundException } from '@nestjs/common'
 import { Prisma } from '@prisma/client'
 
 import { CreateSwapDto, Fees, SwapStatusResponse, UpdateSwapStatusDto } from '@shapeshift/shared-types'
 import { hashAccountId, NotificationsServiceClient, UserServiceClient } from '@shapeshift/shared-utils'
-import { ChainId } from '@shapeshiftoss/caip'
-import type { Swap as SwapperSwap } from '@shapeshiftoss/swapper'
 import { SwapperName, swappers } from '@shapeshiftoss/swapper'
 import { TxStatus } from '@shapeshiftoss/unchained-client'
 
@@ -22,9 +20,24 @@ import { resolveAffiliateFeeAssetId } from '../utils/affiliateFeeAsset'
 import { getNextCursor, swapCursorArgs } from '../utils/pagination'
 import { SwapVerificationService } from '../verification/swap-verification.service'
 
-import type { AggregateFeesParams, FeeTotals, PaginatedSwaps, Swap } from './types'
+import { buildChainAdapterAsserts, getSwapperConfig } from './swapper-config'
+import type {
+  AffiliateVerificationDetails,
+  AggregateFeesParams,
+  FeeTotals,
+  PaginatedSwaps,
+  Swap,
+  SwapReconciliation,
+} from './types'
 import { PaginationQueryDto } from './types'
-import { buildStatusNotification, calculateFeeForSwap, fetchUsdPrices, getAffiliateFeeRate, toSwap } from './utils'
+import {
+  buildStatusNotification,
+  calculateFeeForSwap,
+  fetchUsdPrices,
+  getAffiliateFeeRate,
+  toSwap,
+  toSwapperSwap,
+} from './utils'
 
 const logger = new Logger('SwapsService')
 
@@ -32,25 +45,37 @@ const logger = new Logger('SwapsService')
 export class SwapsService {
   private readonly notificationsClient: NotificationsServiceClient
   private readonly userServiceClient: UserServiceClient
+  private readonly chainAdapterAsserts: ReturnType<typeof buildChainAdapterAsserts>
 
   private static readonly API_BASE_BPS = 10
   private static readonly REFERRER_FEE_RATE = 0.1
 
   constructor(
     private prisma: PrismaService,
-    private evmChainAdapterService: EvmChainAdapterService,
-    private utxoChainAdapterService: UtxoChainAdapterService,
-    private cosmosSdkChainAdapterService: CosmosSdkChainAdapterService,
-    private solanaChainAdapterService: SolanaChainAdapterService,
-    private tronChainAdapterService: TronChainAdapterService,
-    private suiChainAdapterService: SuiChainAdapterService,
-    private nearChainAdapterService: NearChainAdapterService,
-    private starknetChainAdapterService: StarknetChainAdapterService,
-    private tonChainAdapterService: TonChainAdapterService,
     private swapVerificationService: SwapVerificationService,
+    evmChainAdapterService: EvmChainAdapterService,
+    utxoChainAdapterService: UtxoChainAdapterService,
+    cosmosSdkChainAdapterService: CosmosSdkChainAdapterService,
+    solanaChainAdapterService: SolanaChainAdapterService,
+    tronChainAdapterService: TronChainAdapterService,
+    suiChainAdapterService: SuiChainAdapterService,
+    nearChainAdapterService: NearChainAdapterService,
+    starknetChainAdapterService: StarknetChainAdapterService,
+    tonChainAdapterService: TonChainAdapterService,
   ) {
     this.notificationsClient = new NotificationsServiceClient()
     this.userServiceClient = new UserServiceClient()
+    this.chainAdapterAsserts = buildChainAdapterAsserts({
+      evmChainAdapterService,
+      utxoChainAdapterService,
+      cosmosSdkChainAdapterService,
+      solanaChainAdapterService,
+      tronChainAdapterService,
+      suiChainAdapterService,
+      nearChainAdapterService,
+      starknetChainAdapterService,
+      tonChainAdapterService,
+    })
   }
 
   async createSwap(data: CreateSwapDto): Promise<Swap> {
@@ -316,171 +341,39 @@ export class SwapsService {
   }
 
   async pollSwapStatus(swapId: string): Promise<SwapStatusResponse> {
+    logger.log(`Polling status for swap: ${swapId}`)
+
+    const prismaSwap = await this.prisma.swap.findUnique({ where: { swapId } })
+    if (!prismaSwap) throw new NotFoundException(`Swap not found: ${swapId}`)
+
+    const swap = toSwap(prismaSwap)
+
+    const swapper = swappers[swap.swapperName as SwapperName]
+    if (!swapper) throw new NotFoundException(`Swapper not found: ${swap.swapperName}`)
+
+    if (!swap.sellTxHash) throw new BadRequestException('Sell tx hash is required')
+
     try {
-      logger.log(`Polling status for swap: ${swapId}`)
-
-      const rawSwap = await this.prisma.swap.findUnique({
-        where: { swapId },
-      })
-
-      if (!rawSwap) {
-        throw new Error(`Swap not found: ${swapId}`)
-      }
-
-      const swap = toSwap(rawSwap)
-
-      const swapper = swappers[swap.swapperName as SwapperName]
-
-      if (!swapper) {
-        throw new Error(`Swapper not found: ${swap.swapperName}`)
-      }
-
-      if (!swap.sellTxHash) {
-        throw new Error('Sell tx hash is required')
-      }
-
-      const status = await swapper.checkTradeStatus({
-        txHash: swap.sellTxHash ?? '',
+      const { status, buyTxHash, message } = await swapper.checkTradeStatus({
+        txHash: swap.sellTxHash,
         chainId: swap.sellAsset.chainId,
         address: swap.sellAccountId,
-        swap: {
-          ...swap,
-          id: swap.swapId,
-          createdAt: swap.createdAt.getTime(),
-          updatedAt: swap.updatedAt.getTime(),
-        } as unknown as SwapperSwap,
+        swap: toSwapperSwap(swap),
         stepIndex: swap.metadata.stepIndex,
-        config: {
-          VITE_UNCHAINED_THORCHAIN_HTTP_URL: process.env.VITE_UNCHAINED_THORCHAIN_HTTP_URL || '',
-          VITE_UNCHAINED_MAYACHAIN_HTTP_URL: process.env.VITE_UNCHAINED_MAYACHAIN_HTTP_URL || '',
-          VITE_UNCHAINED_COSMOS_HTTP_URL: process.env.VITE_UNCHAINED_COSMOS_HTTP_URL || '',
-          VITE_THORCHAIN_NODE_URL: process.env.VITE_THORCHAIN_NODE_URL || '',
-          VITE_MAYACHAIN_NODE_URL: process.env.VITE_MAYACHAIN_NODE_URL || '',
-          VITE_COWSWAP_BASE_URL: process.env.VITE_COWSWAP_BASE_URL || '',
-          VITE_CHAINFLIP_API_KEY: process.env.VITE_CHAINFLIP_API_KEY || '',
-          VITE_CHAINFLIP_API_URL: process.env.VITE_CHAINFLIP_API_URL || '',
-          VITE_RELAY_API_URL: process.env.VITE_RELAY_API_URL || '',
-          VITE_PORTALS_BASE_URL: process.env.VITE_PORTALS_BASE_URL || '',
-          VITE_ZRX_BASE_URL: process.env.VITE_ZRX_BASE_URL || '',
-          VITE_THORCHAIN_MIDGARD_URL: process.env.VITE_THORCHAIN_MIDGARD_URL || '',
-          VITE_MAYACHAIN_MIDGARD_URL: process.env.VITE_MAYACHAIN_MIDGARD_URL || '',
-          VITE_UNCHAINED_BITCOIN_HTTP_URL: process.env.VITE_UNCHAINED_BITCOIN_HTTP_URL || '',
-          VITE_UNCHAINED_DOGECOIN_HTTP_URL: process.env.VITE_UNCHAINED_DOGECOIN_HTTP_URL || '',
-          VITE_UNCHAINED_LITECOIN_HTTP_URL: process.env.VITE_UNCHAINED_LITECOIN_HTTP_URL || '',
-          VITE_UNCHAINED_BITCOINCASH_HTTP_URL: process.env.VITE_UNCHAINED_BITCOINCASH_HTTP_URL || '',
-          VITE_UNCHAINED_ETHEREUM_HTTP_URL: process.env.VITE_UNCHAINED_ETHEREUM_HTTP_URL || '',
-          VITE_UNCHAINED_AVALANCHE_HTTP_URL: process.env.VITE_UNCHAINED_AVALANCHE_HTTP_URL || '',
-          VITE_UNCHAINED_BNBSMARTCHAIN_HTTP_URL: process.env.VITE_UNCHAINED_BNBSMARTCHAIN_HTTP_URL || '',
-          VITE_UNCHAINED_BASE_HTTP_URL: process.env.VITE_UNCHAINED_BASE_HTTP_URL || '',
-          VITE_NEAR_INTENTS_API_KEY: process.env.VITE_NEAR_INTENTS_API_KEY || '',
-          VITE_BEBOP_API_KEY: process.env.VITE_BEBOP_API_KEY || '',
-          VITE_TENDERLY_API_KEY: process.env.VITE_TENDERLY_API_KEY || '',
-          VITE_TENDERLY_ACCOUNT_SLUG: process.env.VITE_TENDERLY_ACCOUNT_SLUG || '',
-          VITE_TENDERLY_PROJECT_SLUG: process.env.VITE_TENDERLY_PROJECT_SLUG || '',
-          VITE_TRON_NODE_URL: process.env.VITE_TRON_NODE_URL || '',
-          VITE_SUI_NODE_URL: process.env.VITE_SUI_NODE_URL || '',
-          VITE_ACROSS_API_URL: process.env.VITE_ACROSS_API_URL || '',
-          VITE_ACROSS_INTEGRATOR_ID: process.env.VITE_ACROSS_INTEGRATOR_ID || '',
-          VITE_DEBRIDGE_API_URL: process.env.VITE_DEBRIDGE_API_URL || '',
-          VITE_FEATURE_THORCHAINSWAP_LONGTAIL: true,
-          VITE_FEATURE_THORCHAINSWAP_L1_TO_LONGTAIL: true,
-          VITE_FEATURE_CHAINFLIP_SWAP_DCA: true,
-        },
-        assertGetSolanaChainAdapter: (chainId: ChainId) => {
-          return this.solanaChainAdapterService.assertGetSolanaChainAdapter(chainId)
-        },
-        assertGetUtxoChainAdapter: (chainId: ChainId) => {
-          return this.utxoChainAdapterService.assertGetUtxoChainAdapter(chainId)
-        },
-        assertGetCosmosSdkChainAdapter: (chainId: ChainId) => {
-          return this.cosmosSdkChainAdapterService.assertGetCosmosSdkChainAdapter(chainId)
-        },
-        assertGetEvmChainAdapter: (chainId: ChainId) => {
-          return this.evmChainAdapterService.assertGetEvmChainAdapter(chainId)
-        },
-        assertGetTronChainAdapter: (chainId: ChainId) => {
-          return this.tronChainAdapterService.assertGetTronChainAdapter(chainId)
-        },
-        assertGetSuiChainAdapter: (chainId: ChainId) => {
-          return this.suiChainAdapterService.assertGetSuiChainAdapter(chainId)
-        },
-        assertGetNearChainAdapter: (chainId: ChainId) => {
-          return this.nearChainAdapterService.assertGetNearChainAdapter(chainId)
-        },
-        assertGetStarknetChainAdapter: (chainId: ChainId) => {
-          return this.starknetChainAdapterService.assertGetStarknetChainAdapter(chainId)
-        },
-        assertGetTonChainAdapter: (chainId: ChainId) => {
-          return this.tonChainAdapterService.assertGetTonChainAdapter(chainId)
-        },
+        config: getSwapperConfig(),
+        ...this.chainAdapterAsserts,
         fetchIsSmartContractAddressQuery: () => Promise.resolve(false),
       })
 
-      // Verify affiliate usage
-      let isAffiliateVerified: boolean | undefined
-      let affiliateVerificationDetails:
-        | {
-            hasAffiliate: boolean
-            affiliateBps?: number
-            affiliateAddress?: string
-            verifiedSellAmountCryptoBaseUnit?: string
-          }
-        | undefined
+      const statusMessage = Array.isArray(message) ? message[0] : message
 
-      try {
-        const enrichedMetadata = {
-          ...(swap.metadata as Record<string, any>),
-          receiveAddress: swap.receiveAddress,
-          expectedBuyAmountCryptoBaseUnit: swap.expectedBuyAmountCryptoBaseUnit,
-          createdAt: swap.createdAt.getTime(),
-          sellAssetPrecision: swap.sellAsset.precision,
-          affiliateBps: swap.affiliateBps,
-          affiliateAddress: swap.affiliateAddress,
-          integratorFeeRecipient: swap.affiliateAddress,
-          sellAmountCryptoBaseUnit: swap.sellAmountCryptoBaseUnit,
-        }
-
-        const verificationResult = await this.swapVerificationService.verifySwapAffiliate(
-          swapId,
-          swap.swapperName,
-          swap.sellAsset.chainId,
-          swap.sellTxHash || undefined,
-          enrichedMetadata,
-        )
-
-        isAffiliateVerified = verificationResult.isVerified && verificationResult.hasAffiliate
-
-        if (verificationResult.isVerified) {
-          affiliateVerificationDetails = {
-            hasAffiliate: verificationResult.hasAffiliate,
-            affiliateBps: verificationResult.affiliateBps,
-            affiliateAddress: verificationResult.affiliateAddress,
-            verifiedSellAmountCryptoBaseUnit: verificationResult.verifiedSellAmountCryptoBaseUnit,
-          }
-        }
-
-        logger.log(
-          `Affiliate verification for swap ${swapId}: verified=${verificationResult.isVerified}, hasAffiliate=${verificationResult.hasAffiliate}`,
-        )
-
-        await this.prisma.swap.update({
-          where: { swapId },
-          data: {
-            isAffiliateVerified,
-            affiliateVerificationDetails: affiliateVerificationDetails || {},
-          },
-        })
-      } catch (verificationError) {
-        logger.warn(`Failed to verify affiliate for swap ${swapId}:`, verificationError)
-      }
+      const { isAffiliateVerified, affiliateVerificationDetails } = await this.reconcileSwap(swap)
 
       return {
-        status:
-          status.status === TxStatus.Confirmed ? 'SUCCESS' : status.status === TxStatus.Failed ? 'FAILED' : 'PENDING',
+        status: status === TxStatus.Confirmed ? 'SUCCESS' : status === TxStatus.Failed ? 'FAILED' : 'PENDING',
         sellTxHash: swap.sellTxHash,
-        buyTxHash: status.buyTxHash,
-        statusMessage:
-          typeof status.message === 'string' ? status.message : Array.isArray(status.message) ? status.message[0] : '',
+        buyTxHash,
+        statusMessage: typeof statusMessage === 'string' ? statusMessage : '',
         isAffiliateVerified,
         affiliateVerificationDetails,
       }
@@ -490,6 +383,67 @@ export class SwapsService {
         status: 'PENDING',
         statusMessage: `Error polling status: ${error instanceof Error ? error.message : 'Unknown error'}`,
       }
+    }
+  }
+
+  private async reconcileSwap(swap: Swap): Promise<SwapReconciliation> {
+    try {
+      const enrichedMetadata = {
+        ...(swap.metadata as Record<string, any>),
+        receiveAddress: swap.receiveAddress,
+        expectedBuyAmountCryptoBaseUnit: swap.expectedBuyAmountCryptoBaseUnit,
+        createdAt: swap.createdAt.getTime(),
+        sellAssetPrecision: swap.sellAsset.precision,
+        affiliateBps: swap.affiliateBps,
+        affiliateAddress: swap.affiliateAddress,
+        // Some verifiers look for the recipient under `integratorFeeRecipient` rather than `affiliateAddress`.
+        integratorFeeRecipient: swap.affiliateAddress,
+        sellAmountCryptoBaseUnit: swap.sellAmountCryptoBaseUnit,
+      }
+
+      const verificationResult = await this.swapVerificationService.verifySwapAffiliate(
+        swap.swapId,
+        swap.swapperName,
+        swap.sellAsset.chainId,
+        swap.sellTxHash || undefined,
+        enrichedMetadata,
+      )
+
+      const isAffiliateVerified = verificationResult.isVerified && verificationResult.hasAffiliate
+
+      const affiliateVerificationDetails: AffiliateVerificationDetails | undefined = verificationResult.isVerified
+        ? {
+            hasAffiliate: verificationResult.hasAffiliate,
+            affiliateBps: verificationResult.affiliateBps,
+            affiliateAddress: verificationResult.affiliateAddress,
+            verifiedSellAmountCryptoBaseUnit: verificationResult.verifiedSellAmountCryptoBaseUnit,
+          }
+        : undefined
+
+      logger.log(
+        [
+          `Swap verified: ${swap.swapId}`,
+          verificationResult.isVerified ? 'ok' : 'failed',
+          verificationResult.hasAffiliate &&
+            `affiliate ${verificationResult.affiliateAddress} (${verificationResult.affiliateBps} bps)`,
+          verificationResult.error && `error: ${verificationResult.error}`,
+        ]
+          .filter(Boolean)
+          .join(' | '),
+      )
+
+      await this.prisma.swap.update({
+        where: { swapId: swap.swapId },
+        data: {
+          isAffiliateVerified,
+          affiliateVerificationDetails: affiliateVerificationDetails ?? Prisma.DbNull,
+        },
+      })
+
+      return { isAffiliateVerified, affiliateVerificationDetails }
+    } catch (error) {
+      logger.warn(`Failed to verify affiliate for swap ${swap.swapId}:`, error)
+      return {}
     }
   }
 }

--- a/apps/swap-service/src/swaps/swaps.service.ts
+++ b/apps/swap-service/src/swaps/swaps.service.ts
@@ -24,7 +24,8 @@ import { resolveAffiliateFeeAssetId } from '../utils/affiliateFeeAsset'
 import { getNextCursor, swapCursorArgs } from '../utils/pagination'
 import { SwapVerificationService } from '../verification/swap-verification.service'
 
-import type { AffiliateVerificationDetails, PaginationOptions, Swap } from './types'
+import type { AffiliateVerificationDetails, PaginatedSwaps, Swap } from './types'
+import { PaginationQueryDto } from './types'
 import {
   buildStatusNotification,
   estimateAffiliateFeeAmount,
@@ -185,25 +186,27 @@ export class SwapsService {
     })
   }
 
-  async getSwapsByUser(userId: string, options: PaginationOptions = {}) {
+  async getSwapById(swapId: string): Promise<Swap | null> {
+    const prismaSwap = await this.prisma.swap.findUnique({ where: { swapId } })
+    return prismaSwap ? toSwap(prismaSwap) : null
+  }
+
+  async getSwapsByUser(userId: string, options: PaginationQueryDto): Promise<PaginatedSwaps> {
     return this.paginateSwaps({ userId }, options)
   }
 
-  async getSwapsByAccountId(accountId: string, options: PaginationOptions = {}) {
+  async getSwapsByAccountId(accountId: string, options: PaginationQueryDto): Promise<PaginatedSwaps> {
     const hashedAccountId = hashAccountId(accountId)
 
-    return this.paginateSwaps(
-      {
-        OR: [{ sellAccountId: hashedAccountId }, { buyAccountId: hashedAccountId }],
-      },
-      options,
-    )
+    return this.paginateSwaps({ OR: [{ sellAccountId: hashedAccountId }, { buyAccountId: hashedAccountId }] }, options)
   }
 
-  private async paginateSwaps(where: Prisma.SwapWhereInput, { limit = 50, cursor }: PaginationOptions) {
-    const items = await this.prisma.swap.findMany({ where, ...swapCursorArgs(limit, cursor) })
+  private async paginateSwaps(where: Prisma.SwapWhereInput, options: PaginationQueryDto): Promise<PaginatedSwaps> {
+    const { limit, cursor } = options
 
-    return { items, nextCursor: getNextCursor(items, limit) }
+    const rows = await this.prisma.swap.findMany({ where, ...swapCursorArgs(limit, cursor) })
+
+    return { items: rows.map(toSwap), nextCursor: getNextCursor(rows, limit) }
   }
 
   async getPendingSwaps(): Promise<Swap[]> {
@@ -627,9 +630,4 @@ export class SwapsService {
     }
   }
 
-  async findSwapBySwapId(swapId: string) {
-    return this.prisma.swap.findUnique({
-      where: { swapId },
-    })
-  }
 }

--- a/apps/swap-service/src/swaps/swaps.service.ts
+++ b/apps/swap-service/src/swaps/swaps.service.ts
@@ -2,12 +2,7 @@ import { Injectable, Logger } from '@nestjs/common'
 import { Prisma } from '@prisma/client'
 
 import { CreateSwapDto, SwapStatusResponse, UpdateSwapStatusDto } from '@shapeshift/shared-types'
-import {
-  baseUnitToPrecision,
-  hashAccountId,
-  NotificationsServiceClient,
-  UserServiceClient,
-} from '@shapeshift/shared-utils'
+import { hashAccountId, NotificationsServiceClient, UserServiceClient } from '@shapeshift/shared-utils'
 import { ChainId } from '@shapeshiftoss/caip'
 import { bnOrZero } from '@shapeshiftoss/chain-adapters'
 import type { Swap as SwapperSwap } from '@shapeshiftoss/swapper'
@@ -31,18 +26,19 @@ import { SwapVerificationService } from '../verification/swap-verification.servi
 
 import type { AffiliateVerificationDetails, PaginationOptions, Swap } from './types'
 import {
+  buildStatusNotification,
   estimateAffiliateFeeAmount,
   fetchUsdPrices,
-  formatAmount,
   getAffiliateCommissionRate,
   resolveFeeAssetPrice,
   resolveSwapSellAmountUsd,
   toSwap,
 } from './utils'
 
+const logger = new Logger('SwapsService')
+
 @Injectable()
 export class SwapsService {
-  private readonly logger = new Logger(SwapsService.name)
   private readonly notificationsClient: NotificationsServiceClient
   private readonly userServiceClient: UserServiceClient
 
@@ -75,7 +71,7 @@ export class SwapsService {
         this.resolveAffiliateAddress(data),
       ])
 
-      if (referralCode) this.logger.debug(`Found referral code ${referralCode} for user ${data.userId}`)
+      if (referralCode) logger.debug(`Found referral code ${referralCode} for user ${data.userId}`)
 
       const swap = toSwap(
         await this.prisma.swap.create({
@@ -107,7 +103,7 @@ export class SwapsService {
         }),
       )
 
-      this.logger.log(
+      logger.log(
         [
           `Swap created: ${swap.swapId}`,
           referralCode && `referral ${referralCode}`,
@@ -120,7 +116,7 @@ export class SwapsService {
 
       return swap
     } catch (error) {
-      this.logger.error('Failed to create swap', error)
+      logger.error('Failed to create swap', error)
       throw error
     }
   }
@@ -139,9 +135,10 @@ export class SwapsService {
         where: { partnerCode: data.partnerCode },
         select: { receiveAddress: true, walletAddress: true },
       })
+
       return affiliate?.receiveAddress ?? affiliate?.walletAddress ?? null
     } catch (error) {
-      this.logger.warn(`Failed to resolve affiliate address for partner code ${data.partnerCode}:`, error)
+      logger.warn(`Failed to resolve affiliate address for partner code ${data.partnerCode}:`, error)
       return null
     }
   }
@@ -165,69 +162,27 @@ export class SwapsService {
       try {
         await this.sendStatusUpdateNotification(swap)
       } catch (notifError) {
-        this.logger.error(`Failed to send notification for swap ${swap.swapId}:`, notifError)
+        logger.error(`Failed to send notification for swap ${swap.swapId}:`, notifError)
       }
 
-      this.logger.log(`Swap status updated: ${swap.swapId} -> ${swap.status}`)
+      logger.log(`Swap status updated: ${swap.swapId} -> ${swap.status}`)
 
       return swap
     } catch (error) {
-      this.logger.error('Failed to update swap status', error)
+      logger.error('Failed to update swap status', error)
       throw error
     }
   }
 
-  private async sendStatusUpdateNotification(
-    swap: Pick<
-      Swap,
-      | 'swapId'
-      | 'userId'
-      | 'status'
-      | 'sellAsset'
-      | 'buyAsset'
-      | 'sellAmountCryptoBaseUnit'
-      | 'actualBuyAmountCryptoBaseUnit'
-      | 'expectedBuyAmountCryptoBaseUnit'
-    >,
-  ) {
-    let title: string
-    let body: string
-    let type: 'SWAP_STATUS_UPDATE' | 'SWAP_COMPLETED' | 'SWAP_FAILED'
+  private async sendStatusUpdateNotification(swap: Swap) {
+    const notification = buildStatusNotification(swap)
+    if (!notification) return
 
-    const { sellAsset, buyAsset } = swap
-
-    switch (swap.status) {
-      case 'SUCCESS': {
-        title = 'Swap Completed!'
-        const sellAmount = formatAmount(baseUnitToPrecision(swap.sellAmountCryptoBaseUnit, sellAsset.precision))
-        const buyAmount = formatAmount(
-          baseUnitToPrecision(
-            swap.actualBuyAmountCryptoBaseUnit || swap.expectedBuyAmountCryptoBaseUnit,
-            buyAsset.precision,
-          ),
-        )
-        body = `Your swap of ${sellAmount} ${sellAsset.symbol} to ${buyAmount} ${buyAsset.symbol} is complete.`
-        type = 'SWAP_COMPLETED'
-        break
-      }
-      case 'FAILED':
-        title = 'Swap Failed'
-        body = `Your ${sellAsset.symbol} to ${buyAsset.symbol} swap has failed`
-        type = 'SWAP_FAILED'
-        break
-      default:
-        return
-    }
-
-    if (swap.status === 'FAILED' || swap.status === 'SUCCESS') {
-      await this.notificationsClient.createNotification({
-        userId: swap.userId,
-        title,
-        body,
-        type,
-        swapId: swap.swapId,
-      })
-    }
+    await this.notificationsClient.createNotification({
+      ...notification,
+      swapId: swap.swapId,
+      userId: swap.userId,
+    })
   }
 
   async getSwapsByUser(userId: string, options: PaginationOptions = {}) {
@@ -265,7 +220,7 @@ export class SwapsService {
   }
 
   async calculateReferralFees(referralCode: string, startDate?: Date, endDate?: Date) {
-    this.logger.log(
+    logger.log(
       `Calculating referral fees for code: ${referralCode}, period: ${startDate?.toISOString()} - ${endDate?.toISOString()}`,
     )
 
@@ -300,7 +255,7 @@ export class SwapsService {
       select: referralSwapSelect,
     })
 
-    this.logger.log(
+    logger.log(
       `Found ${periodSwaps.length} swaps for period, ${allTimeSwaps.length} swaps all-time for referral code ${referralCode}`,
     )
 
@@ -327,7 +282,7 @@ export class SwapsService {
     const periodReferrerCommissionUsd = period.totalFeesUsd * 0.1
     const allTimeReferrerCommissionUsd = allTime.totalFeesUsd * 0.1
 
-    this.logger.log(
+    logger.log(
       `Referral fee calculation for ${referralCode}: ` +
         `Period: ${periodSwaps.length} swaps, $${period.totalVolumeUsd.toFixed(2)} volume, $${periodReferrerCommissionUsd.toFixed(2)} commission | ` +
         `All-time: ${allTimeSwaps.length} swaps, $${allTimeReferrerCommissionUsd.toFixed(2)} total commission`,
@@ -347,7 +302,7 @@ export class SwapsService {
   async calculateAffiliateFees(affiliateAddress: string, startDate?: Date, endDate?: Date) {
     const normalizedAddress = affiliateAddress.toLowerCase()
 
-    this.logger.log(
+    logger.log(
       `Calculating affiliate fees for address: ${normalizedAddress}, period: ${startDate?.toISOString()} - ${endDate?.toISOString()}`,
     )
 
@@ -394,7 +349,7 @@ export class SwapsService {
       select: swapSelect,
     })
 
-    this.logger.log(
+    logger.log(
       `Found ${periodSwaps.length} swaps for period, ${allTimeSwaps.length} swaps all-time for affiliate ${normalizedAddress}`,
     )
 
@@ -412,7 +367,7 @@ export class SwapsService {
       allTimeCommissionUsd += feeUsd
     }
 
-    this.logger.log(
+    logger.log(
       `Affiliate fee calculation for ${normalizedAddress}: ` +
         `Period: ${periodSwaps.length} swaps, $${totalSwapVolumeUsd.toFixed(2)} volume, $${periodCommissionUsd.toFixed(2)} commission | ` +
         `All-time: ${allTimeSwaps.length} swaps, $${allTimeCommissionUsd.toFixed(2)} total commission`,
@@ -496,7 +451,7 @@ export class SwapsService {
 
   async pollSwapStatus(swapId: string): Promise<SwapStatusResponse> {
     try {
-      this.logger.log(`Polling status for swap: ${swapId}`)
+      logger.log(`Polling status for swap: ${swapId}`)
 
       const rawSwap = await this.prisma.swap.findUnique({
         where: { swapId },
@@ -638,7 +593,7 @@ export class SwapsService {
           }
         }
 
-        this.logger.log(
+        logger.log(
           `Affiliate verification for swap ${swapId}: verified=${verificationResult.isVerified}, hasAffiliate=${verificationResult.hasAffiliate}`,
         )
 
@@ -650,7 +605,7 @@ export class SwapsService {
           },
         })
       } catch (verificationError) {
-        this.logger.warn(`Failed to verify affiliate for swap ${swapId}:`, verificationError)
+        logger.warn(`Failed to verify affiliate for swap ${swapId}:`, verificationError)
       }
 
       return {
@@ -664,7 +619,7 @@ export class SwapsService {
         affiliateVerificationDetails,
       }
     } catch (error) {
-      this.logger.error(`Failed to poll swap status for ${swapId}:`, error)
+      logger.error(`Failed to poll swap status for ${swapId}:`, error)
       return {
         status: 'PENDING',
         statusMessage: `Error polling status: ${error instanceof Error ? error.message : 'Unknown error'}`,

--- a/apps/swap-service/src/swaps/types.ts
+++ b/apps/swap-service/src/swaps/types.ts
@@ -16,7 +16,12 @@ export type AffiliateVerificationDetails = {
   affiliateBps?: number
   affiliateAddress?: string
   verifiedSellAmountCryptoBaseUnit?: string
-  hasAffiliate?: boolean
+  hasAffiliate: boolean
+}
+
+export type SwapReconciliation = {
+  isAffiliateVerified?: boolean
+  affiliateVerificationDetails?: AffiliateVerificationDetails
 }
 
 export type UsdPrices = {

--- a/apps/swap-service/src/swaps/types.ts
+++ b/apps/swap-service/src/swaps/types.ts
@@ -26,3 +26,9 @@ export type PaginationOptions = {
   limit?: number
   cursor?: string
 }
+
+export type StatusNotification = {
+  title: string
+  body: string
+  type: 'SWAP_COMPLETED' | 'SWAP_FAILED'
+}

--- a/apps/swap-service/src/swaps/types.ts
+++ b/apps/swap-service/src/swaps/types.ts
@@ -1,0 +1,26 @@
+import type { Swap } from '@prisma/client'
+
+import type { Asset } from '@shapeshiftoss/types'
+
+export type SwapWithAssets = Omit<Swap, 'sellAsset' | 'buyAsset'> & {
+  sellAsset: Asset
+  buyAsset: Asset
+}
+
+export type AffiliateVerificationDetails = {
+  affiliateBps?: number
+  affiliateAddress?: string
+  verifiedSellAmountCryptoBaseUnit?: string
+  hasAffiliate?: boolean
+}
+
+export type UsdPrices = {
+  sellAmountUsd: string | null
+  buyAssetUsd: string | null
+  affiliateAssetUsd: string | null
+}
+
+export type PaginationOptions = {
+  limit?: number
+  cursor?: string
+}

--- a/apps/swap-service/src/swaps/types.ts
+++ b/apps/swap-service/src/swaps/types.ts
@@ -1,14 +1,15 @@
-import type { Swap as PrismaSwap } from '@prisma/client'
+import type { Prisma, Swap as PrismaSwap } from '@prisma/client'
 import { Type } from 'class-transformer'
 import { IsInt, IsOptional, IsString, Max, Min } from 'class-validator'
 
 import type { SwapperSpecificMetadata } from '@shapeshiftoss/swapper'
 import type { Asset } from '@shapeshiftoss/types'
 
-export type Swap = Omit<PrismaSwap, 'sellAsset' | 'buyAsset' | 'metadata'> & {
+export type Swap = Omit<PrismaSwap, 'sellAsset' | 'buyAsset' | 'metadata' | 'affiliateVerificationDetails'> & {
   sellAsset: Asset
   buyAsset: Asset
   metadata: SwapperSpecificMetadata
+  affiliateVerificationDetails: AffiliateVerificationDetails | null
 }
 
 export type AffiliateVerificationDetails = {
@@ -22,6 +23,21 @@ export type UsdPrices = {
   sellAmountUsd: string | null
   buyAssetUsd: string | null
   affiliateAssetUsd: string | null
+}
+
+export type FeeTotals = {
+  periodCount: number
+  periodVolumeUsd: number
+  periodFeesUsd: number
+  allTimeCount: number
+  allTimeFeesUsd: number
+}
+
+export type AggregateFeesParams = {
+  baseWhere: Prisma.SwapWhereInput
+  startDate?: Date
+  endDate?: Date
+  calcFee: (swap: Swap) => { feeUsd: number; volumeUsd: number } | null
 }
 
 export type PaginatedSwaps = {

--- a/apps/swap-service/src/swaps/types.ts
+++ b/apps/swap-service/src/swaps/types.ts
@@ -1,11 +1,20 @@
-import type { Swap } from '@prisma/client'
+import type { Swap as PrismaSwap } from '@prisma/client'
 
+import type { SwapperSpecificMetadata } from '@shapeshiftoss/swapper'
 import type { Asset } from '@shapeshiftoss/types'
 
-export type SwapWithAssets = Omit<Swap, 'sellAsset' | 'buyAsset'> & {
+export type Swap = Omit<PrismaSwap, 'sellAsset' | 'buyAsset' | 'metadata'> & {
   sellAsset: Asset
   buyAsset: Asset
+  metadata: SwapperSpecificMetadata
 }
+
+export const toSwap = (swap: PrismaSwap): Swap => ({
+  ...swap,
+  sellAsset: swap.sellAsset as Asset,
+  buyAsset: swap.buyAsset as Asset,
+  metadata: swap.metadata as SwapperSpecificMetadata,
+})
 
 export type AffiliateVerificationDetails = {
   affiliateBps?: number

--- a/apps/swap-service/src/swaps/types.ts
+++ b/apps/swap-service/src/swaps/types.ts
@@ -1,4 +1,6 @@
 import type { Swap as PrismaSwap } from '@prisma/client'
+import { Type } from 'class-transformer'
+import { IsInt, IsOptional, IsString, Max, Min } from 'class-validator'
 
 import type { SwapperSpecificMetadata } from '@shapeshiftoss/swapper'
 import type { Asset } from '@shapeshiftoss/types'
@@ -22,8 +24,21 @@ export type UsdPrices = {
   affiliateAssetUsd: string | null
 }
 
-export type PaginationOptions = {
-  limit?: number
+export type PaginatedSwaps = {
+  items: Swap[]
+  nextCursor: string | null
+}
+
+export class PaginationQueryDto {
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  @Max(100)
+  limit: number = 50
+
+  @IsOptional()
+  @IsString()
   cursor?: string
 }
 

--- a/apps/swap-service/src/swaps/types.ts
+++ b/apps/swap-service/src/swaps/types.ts
@@ -9,13 +9,6 @@ export type Swap = Omit<PrismaSwap, 'sellAsset' | 'buyAsset' | 'metadata'> & {
   metadata: SwapperSpecificMetadata
 }
 
-export const toSwap = (swap: PrismaSwap): Swap => ({
-  ...swap,
-  sellAsset: swap.sellAsset as Asset,
-  buyAsset: swap.buyAsset as Asset,
-  metadata: swap.metadata as SwapperSpecificMetadata,
-})
-
 export type AffiliateVerificationDetails = {
   affiliateBps?: number
   affiliateAddress?: string

--- a/apps/swap-service/src/swaps/utils.ts
+++ b/apps/swap-service/src/swaps/utils.ts
@@ -1,7 +1,7 @@
 import { Logger } from '@nestjs/common'
 import type { Swap as PrismaSwap } from '@prisma/client'
 
-import { CreateSwapDto } from '@shapeshift/shared-types'
+import type { CreateSwapDto } from '@shapeshift/shared-types'
 import { baseUnitToPrecision } from '@shapeshift/shared-utils'
 import { bnOrZero } from '@shapeshiftoss/chain-adapters'
 import type { SwapperSpecificMetadata } from '@shapeshiftoss/swapper'
@@ -12,7 +12,7 @@ import { getAssetPriceUsd } from '../utils/pricing'
 
 import type { Swap, UsdPrices } from './types'
 
-const logger = new Logger('SwapsUtils')
+const logger = new Logger('SwapsService')
 
 export const toSwap = (swap: PrismaSwap): Swap => ({
   ...swap,
@@ -59,10 +59,7 @@ export const estimateAffiliateFeeAmount = (
   }
 }
 
-export const fetchUsdPrices = async (
-  data: CreateSwapDto,
-  affiliateFeeAssetId: string | null,
-): Promise<UsdPrices> => {
+export const fetchUsdPrices = async (data: CreateSwapDto, affiliateFeeAssetId: string | null): Promise<UsdPrices> => {
   try {
     const [sellAssetUsd, buyAssetUsd, affiliateAssetUsd] = await Promise.all([
       getAssetPriceUsd(data.sellAsset.assetId),
@@ -92,7 +89,38 @@ export const resolveSwapSellAmountUsd = (swap: { swapId: string; sellAmountUsd: 
     logger.warn(`Missing sellAmountUsd for swap ${swap.swapId}, skipping`)
     return null
   }
+
   return parseFloat(swap.sellAmountUsd)
+}
+
+export const buildStatusNotification = (
+  swap: Swap,
+): { title: string; body: string; type: 'SWAP_COMPLETED' | 'SWAP_FAILED' } | null => {
+  const { sellAsset, buyAsset } = swap
+  switch (swap.status) {
+    case 'SUCCESS': {
+      const sellAmount = formatAmount(baseUnitToPrecision(swap.sellAmountCryptoBaseUnit, sellAsset.precision))
+      const buyAmount = formatAmount(
+        baseUnitToPrecision(
+          swap.actualBuyAmountCryptoBaseUnit ?? swap.expectedBuyAmountCryptoBaseUnit,
+          buyAsset.precision,
+        ),
+      )
+      return {
+        title: 'Swap Completed!',
+        body: `Your swap of ${sellAmount} ${sellAsset.symbol} to ${buyAmount} ${buyAsset.symbol} is complete.`,
+        type: 'SWAP_COMPLETED',
+      }
+    }
+    case 'FAILED':
+      return {
+        title: 'Swap Failed',
+        body: `Your ${sellAsset.symbol} to ${buyAsset.symbol} swap has failed`,
+        type: 'SWAP_FAILED',
+      }
+    default:
+      return null
+  }
 }
 
 export const resolveFeeAssetPrice = (swap: {

--- a/apps/swap-service/src/swaps/utils.ts
+++ b/apps/swap-service/src/swaps/utils.ts
@@ -95,25 +95,26 @@ export const resolveSwapSellAmountUsd = (swap: { swapId: string; sellAmountUsd: 
 
 export const buildStatusNotification = (swap: Swap): StatusNotification | null => {
   const { sellAsset, buyAsset } = swap
+
+  const sellAmountCryptoPrecision = baseUnitToPrecision(swap.sellAmountCryptoBaseUnit, sellAsset.precision)
+  const sellAmount = formatAmount(sellAmountCryptoPrecision)
+
   switch (swap.status) {
     case 'SUCCESS': {
-      const sellAmount = formatAmount(baseUnitToPrecision(swap.sellAmountCryptoBaseUnit, sellAsset.precision))
-      const buyAmount = formatAmount(
-        baseUnitToPrecision(
-          swap.actualBuyAmountCryptoBaseUnit ?? swap.expectedBuyAmountCryptoBaseUnit,
-          buyAsset.precision,
-        ),
-      )
+      const buyAmountCryptoBaseUnit = swap.actualBuyAmountCryptoBaseUnit ?? swap.expectedBuyAmountCryptoBaseUnit
+      const buyAmoutCryptoPrecision = baseUnitToPrecision(buyAmountCryptoBaseUnit, buyAsset.precision)
+      const buyAmount = formatAmount(buyAmoutCryptoPrecision)
+
       return {
         title: 'Swap Completed!',
-        body: `Your swap of ${sellAmount} ${sellAsset.symbol} to ${buyAmount} ${buyAsset.symbol} is complete.`,
+        body: `Your swap of ${sellAmount} ${sellAsset.symbol} for ${buyAmount} ${buyAsset.symbol} is complete.`,
         type: 'SWAP_COMPLETED',
       }
     }
     case 'FAILED':
       return {
         title: 'Swap Failed',
-        body: `Your ${sellAsset.symbol} to ${buyAsset.symbol} swap has failed`,
+        body: `Your swap of ${sellAmount} ${sellAsset.symbol} for ${buyAsset.symbol} failed.`,
         type: 'SWAP_FAILED',
       }
     default:

--- a/apps/swap-service/src/swaps/utils.ts
+++ b/apps/swap-service/src/swaps/utils.ts
@@ -1,0 +1,76 @@
+import type { Swap as PrismaSwap } from '@prisma/client'
+
+import { bnOrZero } from '@shapeshiftoss/chain-adapters'
+import type { SwapperSpecificMetadata } from '@shapeshiftoss/swapper'
+import type { Asset } from '@shapeshiftoss/types'
+
+import { getSwapperFeeStrategy } from '../utils/affiliateFeeAsset'
+import type { Swap } from './types'
+
+export const toSwap = (swap: PrismaSwap): Swap => ({
+  ...swap,
+  sellAsset: swap.sellAsset as Asset,
+  buyAsset: swap.buyAsset as Asset,
+  metadata: swap.metadata as SwapperSpecificMetadata,
+})
+
+export const formatAmount = (amount: string | number): string => {
+  // up to 8 decimals, no trailing zeros
+  return bnOrZero(amount).toFixed(8).replace(/\.?0+$/, '')
+}
+
+export const getAffiliateCommissionRate = (
+  origin: string | null,
+  verifiedBps: number,
+  shapeshiftBps: number,
+): number => {
+  if (origin === 'web') {
+    // Referrer earns shapeshiftBps of volume (shapeshiftBps / verifiedBps of the fee).
+    return shapeshiftBps / verifiedBps
+  }
+  if (!origin || verifiedBps <= shapeshiftBps) return 0
+  return (verifiedBps - shapeshiftBps) / verifiedBps
+}
+
+export const estimateAffiliateFeeAmount = (
+  affiliateBps: number,
+  swapperName: string,
+  sellAmountCryptoBaseUnit: string,
+  expectedBuyAmountCryptoBaseUnit: string,
+): string => {
+  const strategy = getSwapperFeeStrategy(swapperName)
+  const bpsMultiplier = affiliateBps / 10000
+
+  switch (strategy) {
+    case 'sell_asset':
+      return bnOrZero(sellAmountCryptoBaseUnit).times(bpsMultiplier).toFixed(0)
+    case 'buy_asset':
+      return bnOrZero(expectedBuyAmountCryptoBaseUnit).times(bpsMultiplier).toFixed(0)
+    case 'fixed_base':
+    default:
+      return bnOrZero(sellAmountCryptoBaseUnit).times(bpsMultiplier).toFixed(0)
+  }
+}
+
+export const resolveFeeAssetPrice = (swap: {
+  sellAsset: unknown
+  buyAsset: unknown
+  sellAmountCryptoBaseUnit: string
+  sellAmountUsd: string | null
+  buyAssetUsd: string | null
+  affiliateAssetUsd: string | null
+  affiliateFeeAssetId: string | null
+}): string | null => {
+  if (!swap.affiliateFeeAssetId) return null
+  const sellAssetObj = swap.sellAsset as Asset
+  const buyAssetObj = swap.buyAsset as Asset
+  if (swap.affiliateFeeAssetId === sellAssetObj.assetId && swap.sellAmountUsd) {
+    // Back-derive sell price from stored USD value.
+    const sellAmountPrecision = bnOrZero(swap.sellAmountCryptoBaseUnit).div(bnOrZero(10).pow(sellAssetObj.precision))
+    return sellAmountPrecision.isZero() ? null : bnOrZero(swap.sellAmountUsd).div(sellAmountPrecision).toFixed()
+  }
+  if (swap.affiliateFeeAssetId === buyAssetObj.assetId) {
+    return swap.buyAssetUsd
+  }
+  return swap.affiliateAssetUsd
+}

--- a/apps/swap-service/src/swaps/utils.ts
+++ b/apps/swap-service/src/swaps/utils.ts
@@ -1,11 +1,18 @@
+import { Logger } from '@nestjs/common'
 import type { Swap as PrismaSwap } from '@prisma/client'
 
+import { CreateSwapDto } from '@shapeshift/shared-types'
+import { baseUnitToPrecision } from '@shapeshift/shared-utils'
 import { bnOrZero } from '@shapeshiftoss/chain-adapters'
 import type { SwapperSpecificMetadata } from '@shapeshiftoss/swapper'
 import type { Asset } from '@shapeshiftoss/types'
 
 import { getSwapperFeeStrategy } from '../utils/affiliateFeeAsset'
-import type { Swap } from './types'
+import { getAssetPriceUsd } from '../utils/pricing'
+
+import type { Swap, UsdPrices } from './types'
+
+const logger = new Logger('SwapsUtils')
 
 export const toSwap = (swap: PrismaSwap): Swap => ({
   ...swap,
@@ -14,9 +21,11 @@ export const toSwap = (swap: PrismaSwap): Swap => ({
   metadata: swap.metadata as SwapperSpecificMetadata,
 })
 
+// formatAmount up to 8 decimals, no trailing zeros
 export const formatAmount = (amount: string | number): string => {
-  // up to 8 decimals, no trailing zeros
-  return bnOrZero(amount).toFixed(8).replace(/\.?0+$/, '')
+  return bnOrZero(amount)
+    .toFixed(8)
+    .replace(/\.?0+$/, '')
 }
 
 export const getAffiliateCommissionRate = (
@@ -24,10 +33,8 @@ export const getAffiliateCommissionRate = (
   verifiedBps: number,
   shapeshiftBps: number,
 ): number => {
-  if (origin === 'web') {
-    // Referrer earns shapeshiftBps of volume (shapeshiftBps / verifiedBps of the fee).
-    return shapeshiftBps / verifiedBps
-  }
+  // Referrer earns shapeshiftBps of volume (shapeshiftBps / verifiedBps of the fee).
+  if (origin === 'web') return shapeshiftBps / verifiedBps
   if (!origin || verifiedBps <= shapeshiftBps) return 0
   return (verifiedBps - shapeshiftBps) / verifiedBps
 }
@@ -52,6 +59,42 @@ export const estimateAffiliateFeeAmount = (
   }
 }
 
+export const fetchUsdPrices = async (
+  data: CreateSwapDto,
+  affiliateFeeAssetId: string | null,
+): Promise<UsdPrices> => {
+  try {
+    const [sellAssetUsd, buyAssetUsd, affiliateAssetUsd] = await Promise.all([
+      getAssetPriceUsd(data.sellAsset.assetId),
+      getAssetPriceUsd(data.buyAsset.assetId),
+      affiliateFeeAssetId ? getAssetPriceUsd(affiliateFeeAssetId) : Promise.resolve<number | null>(null),
+    ])
+
+    const sellAmountUsd = sellAssetUsd
+      ? bnOrZero(baseUnitToPrecision(data.sellAmountCryptoBaseUnit, data.sellAsset.precision))
+          .times(sellAssetUsd)
+          .toFixed(2)
+      : null
+
+    return {
+      sellAmountUsd,
+      buyAssetUsd: buyAssetUsd?.toString() ?? null,
+      affiliateAssetUsd: affiliateAssetUsd?.toString() ?? null,
+    }
+  } catch (err) {
+    logger.warn(`Failed to fetch USD prices for swap ${data.swapId}:`, err)
+    return { sellAmountUsd: null, buyAssetUsd: null, affiliateAssetUsd: null }
+  }
+}
+
+export const resolveSwapSellAmountUsd = (swap: { swapId: string; sellAmountUsd: string | null }): number | null => {
+  if (!swap.sellAmountUsd) {
+    logger.warn(`Missing sellAmountUsd for swap ${swap.swapId}, skipping`)
+    return null
+  }
+  return parseFloat(swap.sellAmountUsd)
+}
+
 export const resolveFeeAssetPrice = (swap: {
   sellAsset: unknown
   buyAsset: unknown
@@ -62,15 +105,17 @@ export const resolveFeeAssetPrice = (swap: {
   affiliateFeeAssetId: string | null
 }): string | null => {
   if (!swap.affiliateFeeAssetId) return null
+
   const sellAssetObj = swap.sellAsset as Asset
   const buyAssetObj = swap.buyAsset as Asset
+
   if (swap.affiliateFeeAssetId === sellAssetObj.assetId && swap.sellAmountUsd) {
     // Back-derive sell price from stored USD value.
     const sellAmountPrecision = bnOrZero(swap.sellAmountCryptoBaseUnit).div(bnOrZero(10).pow(sellAssetObj.precision))
     return sellAmountPrecision.isZero() ? null : bnOrZero(swap.sellAmountUsd).div(sellAmountPrecision).toFixed()
   }
-  if (swap.affiliateFeeAssetId === buyAssetObj.assetId) {
-    return swap.buyAssetUsd
-  }
+
+  if (swap.affiliateFeeAssetId === buyAssetObj.assetId) return swap.buyAssetUsd
+
   return swap.affiliateAssetUsd
 }

--- a/apps/swap-service/src/swaps/utils.ts
+++ b/apps/swap-service/src/swaps/utils.ts
@@ -4,7 +4,7 @@ import type { Swap as PrismaSwap } from '@prisma/client'
 import type { CreateSwapDto } from '@shapeshift/shared-types'
 import { baseUnitToPrecision } from '@shapeshift/shared-utils'
 import { bnOrZero } from '@shapeshiftoss/chain-adapters'
-import type { SwapperSpecificMetadata } from '@shapeshiftoss/swapper'
+import type { Swap as SwapperSwap, SwapperSpecificMetadata } from '@shapeshiftoss/swapper'
 import type { Asset } from '@shapeshiftoss/types'
 
 import { getAssetPriceUsd } from '../utils/pricing'
@@ -22,6 +22,14 @@ export const toSwap = (swap: PrismaSwap): Swap => ({
   metadata: swap.metadata as SwapperSpecificMetadata,
   affiliateVerificationDetails: swap.affiliateVerificationDetails as AffiliateVerificationDetails | null,
 })
+
+export const toSwapperSwap = (swap: Swap): SwapperSwap =>
+  ({
+    ...swap,
+    id: swap.swapId,
+    createdAt: swap.createdAt.getTime(),
+    updatedAt: swap.updatedAt.getTime(),
+  }) as unknown as SwapperSwap
 
 // formatAmount up to 8 decimals, no trailing zeros
 export const formatAmount = (amount: string | number): string => {

--- a/apps/swap-service/src/swaps/utils.ts
+++ b/apps/swap-service/src/swaps/utils.ts
@@ -15,12 +15,23 @@ const logger = new Logger('SwapsService')
 
 const BPS_DENOMINATOR = 10000
 
+// Historical rows may persist `{}` for affiliateVerificationDetails; coerce anything
+// that doesn't satisfy the tightened shape (requires `hasAffiliate`) to null.
+const toAffiliateVerificationDetails = (
+  raw: PrismaSwap['affiliateVerificationDetails'],
+): AffiliateVerificationDetails | null => {
+  if (!raw || typeof raw !== 'object') return null
+  const details = raw as Partial<AffiliateVerificationDetails>
+  if (typeof details.hasAffiliate !== 'boolean') return null
+  return details as AffiliateVerificationDetails
+}
+
 export const toSwap = (swap: PrismaSwap): Swap => ({
   ...swap,
   sellAsset: swap.sellAsset as Asset,
   buyAsset: swap.buyAsset as Asset,
   metadata: swap.metadata as SwapperSpecificMetadata,
-  affiliateVerificationDetails: swap.affiliateVerificationDetails as AffiliateVerificationDetails | null,
+  affiliateVerificationDetails: toAffiliateVerificationDetails(swap.affiliateVerificationDetails),
 })
 
 export const toSwapperSwap = (swap: Swap): SwapperSwap =>

--- a/apps/swap-service/src/swaps/utils.ts
+++ b/apps/swap-service/src/swaps/utils.ts
@@ -7,18 +7,20 @@ import { bnOrZero } from '@shapeshiftoss/chain-adapters'
 import type { SwapperSpecificMetadata } from '@shapeshiftoss/swapper'
 import type { Asset } from '@shapeshiftoss/types'
 
-import { getSwapperFeeStrategy } from '../utils/affiliateFeeAsset'
 import { getAssetPriceUsd } from '../utils/pricing'
 
-import type { StatusNotification, Swap, UsdPrices } from './types'
+import type { AffiliateVerificationDetails, StatusNotification, Swap, UsdPrices } from './types'
 
 const logger = new Logger('SwapsService')
+
+const BPS_DENOMINATOR = 10000
 
 export const toSwap = (swap: PrismaSwap): Swap => ({
   ...swap,
   sellAsset: swap.sellAsset as Asset,
   buyAsset: swap.buyAsset as Asset,
   metadata: swap.metadata as SwapperSpecificMetadata,
+  affiliateVerificationDetails: swap.affiliateVerificationDetails as AffiliateVerificationDetails | null,
 })
 
 // formatAmount up to 8 decimals, no trailing zeros
@@ -28,35 +30,11 @@ export const formatAmount = (amount: string | number): string => {
     .replace(/\.?0+$/, '')
 }
 
-export const getAffiliateCommissionRate = (
-  origin: string | null,
-  verifiedBps: number,
-  shapeshiftBps: number,
-): number => {
-  // Referrer earns shapeshiftBps of volume (shapeshiftBps / verifiedBps of the fee).
-  if (origin === 'web') return shapeshiftBps / verifiedBps
-  if (!origin || verifiedBps <= shapeshiftBps) return 0
+export const getAffiliateFeeRate = (verifiedBps: number, shapeshiftBps: number): number => {
+  // Partner configured at or below the platform floor — partner keeps the whole fee.
+  if (verifiedBps <= shapeshiftBps) return 1
+  // Platform takes shapeshiftBps; partner gets the remainder.
   return (verifiedBps - shapeshiftBps) / verifiedBps
-}
-
-export const estimateAffiliateFeeAmount = (
-  affiliateBps: number,
-  swapperName: string,
-  sellAmountCryptoBaseUnit: string,
-  expectedBuyAmountCryptoBaseUnit: string,
-): string => {
-  const strategy = getSwapperFeeStrategy(swapperName)
-  const bpsMultiplier = affiliateBps / 10000
-
-  switch (strategy) {
-    case 'sell_asset':
-      return bnOrZero(sellAmountCryptoBaseUnit).times(bpsMultiplier).toFixed(0)
-    case 'buy_asset':
-      return bnOrZero(expectedBuyAmountCryptoBaseUnit).times(bpsMultiplier).toFixed(0)
-    case 'fixed_base':
-    default:
-      return bnOrZero(sellAmountCryptoBaseUnit).times(bpsMultiplier).toFixed(0)
-  }
 }
 
 export const fetchUsdPrices = async (data: CreateSwapDto, affiliateFeeAssetId: string | null): Promise<UsdPrices> => {
@@ -82,15 +60,6 @@ export const fetchUsdPrices = async (data: CreateSwapDto, affiliateFeeAssetId: s
     logger.warn(`Failed to fetch USD prices for swap ${data.swapId}:`, err)
     return { sellAmountUsd: null, buyAssetUsd: null, affiliateAssetUsd: null }
   }
-}
-
-export const resolveSwapSellAmountUsd = (swap: { swapId: string; sellAmountUsd: string | null }): number | null => {
-  if (!swap.sellAmountUsd) {
-    logger.warn(`Missing sellAmountUsd for swap ${swap.swapId}, skipping`)
-    return null
-  }
-
-  return parseFloat(swap.sellAmountUsd)
 }
 
 export const buildStatusNotification = (swap: Swap): StatusNotification | null => {
@@ -122,27 +91,51 @@ export const buildStatusNotification = (swap: Swap): StatusNotification | null =
   }
 }
 
-export const resolveFeeAssetPrice = (swap: {
-  sellAsset: unknown
-  buyAsset: unknown
-  sellAmountCryptoBaseUnit: string
-  sellAmountUsd: string | null
-  buyAssetUsd: string | null
-  affiliateAssetUsd: string | null
-  affiliateFeeAssetId: string | null
-}): string | null => {
-  if (!swap.affiliateFeeAssetId) return null
+const resolveActualFeeUsd = (swap: Swap): number | null => {
+  const amount = swap.actualAffiliateFeeAmountCryptoBaseUnit
+  if (!amount || !swap.affiliateFeeAssetId) return null
 
-  const sellAssetObj = swap.sellAsset as Asset
-  const buyAssetObj = swap.buyAsset as Asset
+  let priceUsd: string | null
+  let precision: number | null
 
-  if (swap.affiliateFeeAssetId === sellAssetObj.assetId && swap.sellAmountUsd) {
-    // Back-derive sell price from stored USD value.
-    const sellAmountPrecision = bnOrZero(swap.sellAmountCryptoBaseUnit).div(bnOrZero(10).pow(sellAssetObj.precision))
-    return sellAmountPrecision.isZero() ? null : bnOrZero(swap.sellAmountUsd).div(sellAmountPrecision).toFixed()
+  if (swap.affiliateFeeAssetId === swap.sellAsset.assetId) {
+    // Back-derive sell asset price from stored USD value.
+    if (!swap.sellAmountUsd) return null
+    const sellAmount = bnOrZero(swap.sellAmountCryptoBaseUnit).div(bnOrZero(10).pow(swap.sellAsset.precision))
+    if (sellAmount.isZero()) return null
+    priceUsd = bnOrZero(swap.sellAmountUsd).div(sellAmount).toFixed()
+    precision = swap.sellAsset.precision
+  } else if (swap.affiliateFeeAssetId === swap.buyAsset.assetId) {
+    priceUsd = swap.buyAssetUsd
+    precision = swap.buyAsset.precision
+  } else {
+    priceUsd = swap.affiliateAssetUsd
+    // Fee asset is neither sell nor buy — precision unknown
+    precision = null
   }
 
-  if (swap.affiliateFeeAssetId === buyAssetObj.assetId) return swap.buyAssetUsd
+  if (!priceUsd || precision === null) return null
 
-  return swap.affiliateAssetUsd
+  return bnOrZero(amount).div(bnOrZero(10).pow(precision)).times(priceUsd).toNumber()
+}
+
+export const calculateFeeForSwap = (swap: Swap): { feeUsd: number; volumeUsd: number; verifiedBps: number } | null => {
+  const verifiedBps = swap.affiliateVerificationDetails?.affiliateBps
+  if (!verifiedBps) {
+    logger.warn(`Verified swap ${swap.swapId} missing affiliateBps in verification details, skipping`)
+    return null
+  }
+
+  const sellAmountUsd = swap.sellAmountUsd ? parseFloat(swap.sellAmountUsd) : null
+  const actualFeeUsd = resolveActualFeeUsd(swap)
+
+  if (actualFeeUsd === null && sellAmountUsd === null) {
+    logger.warn(`Unable to calculate fee for swap ${swap.swapId}, skipping`)
+    return null
+  }
+
+  const feeUsd = actualFeeUsd ?? bnOrZero(sellAmountUsd).times(verifiedBps).div(BPS_DENOMINATOR).toNumber()
+  const volumeUsd = sellAmountUsd ?? bnOrZero(actualFeeUsd).times(BPS_DENOMINATOR).div(verifiedBps).toNumber()
+
+  return { feeUsd, volumeUsd, verifiedBps }
 }

--- a/apps/swap-service/src/swaps/utils.ts
+++ b/apps/swap-service/src/swaps/utils.ts
@@ -10,7 +10,7 @@ import type { Asset } from '@shapeshiftoss/types'
 import { getSwapperFeeStrategy } from '../utils/affiliateFeeAsset'
 import { getAssetPriceUsd } from '../utils/pricing'
 
-import type { Swap, UsdPrices } from './types'
+import type { StatusNotification, Swap, UsdPrices } from './types'
 
 const logger = new Logger('SwapsService')
 
@@ -93,9 +93,7 @@ export const resolveSwapSellAmountUsd = (swap: { swapId: string; sellAmountUsd: 
   return parseFloat(swap.sellAmountUsd)
 }
 
-export const buildStatusNotification = (
-  swap: Swap,
-): { title: string; body: string; type: 'SWAP_COMPLETED' | 'SWAP_FAILED' } | null => {
+export const buildStatusNotification = (swap: Swap): StatusNotification | null => {
   const { sellAsset, buyAsset } = swap
   switch (swap.status) {
     case 'SUCCESS': {

--- a/apps/swap-service/src/utils/affiliateFeeAsset.ts
+++ b/apps/swap-service/src/utils/affiliateFeeAsset.ts
@@ -35,7 +35,3 @@ export function resolveAffiliateFeeAssetId(swapperName: string, sellAsset: Asset
       return null
   }
 }
-
-export function getSwapperFeeStrategy(swapperName: string): FeeAssetStrategy | null {
-  return SWAPPER_FEE_STRATEGY[swapperName] ?? null
-}

--- a/apps/swap-service/src/utils/pricing.ts
+++ b/apps/swap-service/src/utils/pricing.ts
@@ -3,7 +3,6 @@ import axios from 'axios'
 
 import { adapters } from '@shapeshiftoss/caip'
 import { bnOrZero } from '@shapeshiftoss/chain-adapters'
-import type { Asset } from '@shapeshiftoss/types'
 
 const logger = new Logger('Pricing')
 
@@ -18,16 +17,14 @@ type CoinGeckoAssetData = {
   }
 }
 
-export async function getAssetPriceUsd(asset: Asset): Promise<number | null> {
-  const cacheKey = asset.assetId
-
-  const cached = priceCache.get(cacheKey)
+export async function getAssetPriceUsd(assetId: string): Promise<number | null> {
+  const cached = priceCache.get(assetId)
   if (cached !== undefined) return cached
 
   try {
-    const url = adapters.makeCoingeckoAssetUrl(asset.assetId)
+    const url = adapters.makeCoingeckoAssetUrl(assetId)
     if (!url) {
-      logger.warn(`No CoinGecko URL mapping for assetId: ${asset.assetId}`)
+      logger.warn(`No CoinGecko URL mapping for assetId: ${assetId}`)
       return null
     }
 
@@ -35,16 +32,16 @@ export async function getAssetPriceUsd(asset: Asset): Promise<number | null> {
 
     const price = data?.market_data?.current_price?.usd
     if (!price) {
-      logger.warn(`No price data found for ${asset.assetId} (symbol: ${asset.symbol})`)
+      logger.warn(`No price data found for ${assetId}`)
       return null
     }
 
-    priceCache.set(cacheKey, price)
-    setTimeout(() => priceCache.delete(cacheKey), CACHE_TTL_MS).unref()
+    priceCache.set(assetId, price)
+    setTimeout(() => priceCache.delete(assetId), CACHE_TTL_MS).unref()
 
     return price
   } catch (error) {
-    logger.error(`Failed to fetch price for ${asset.assetId}:`, error)
+    logger.error(`Failed to fetch price for ${assetId}:`, error)
     return null
   }
 }

--- a/apps/swap-service/src/websocket/websocket.gateway.ts
+++ b/apps/swap-service/src/websocket/websocket.gateway.ts
@@ -10,8 +10,8 @@ import {
 } from '@nestjs/websockets'
 import { Server, Socket } from 'socket.io'
 
-import type { SwapWithAssets } from '../swaps/swaps.service'
 import { SwapsService } from '../swaps/swaps.service'
+import type { SwapWithAssets } from '../swaps/types'
 
 interface AuthenticatedSocket extends Socket {
   userId?: string

--- a/apps/swap-service/src/websocket/websocket.gateway.ts
+++ b/apps/swap-service/src/websocket/websocket.gateway.ts
@@ -11,7 +11,7 @@ import {
 import { Server, Socket } from 'socket.io'
 
 import { SwapsService } from '../swaps/swaps.service'
-import type { SwapWithAssets } from '../swaps/types'
+import type { Swap } from '../swaps/types'
 
 interface AuthenticatedSocket extends Socket {
   userId?: string
@@ -61,7 +61,7 @@ export class WebsocketGateway implements OnGatewayConnection, OnGatewayDisconnec
     }
   }
 
-  sendSwapUpdateToUser(userId: string, swap: SwapWithAssets) {
+  sendSwapUpdateToUser(userId: string, swap: Swap) {
     const client = this.connectedClients.get(userId)
     if (client) client.emit('swapUpdate', swap)
     this.server.to(`user:${userId}`).emit('swapUpdate', swap)

--- a/apps/user-service/src/referral/referral.service.ts
+++ b/apps/user-service/src/referral/referral.service.ts
@@ -230,19 +230,14 @@ export class ReferralService {
     const activeCodesCount = referralCodes.filter((code) => code.isActive).length
 
     // Fetch fee data from swap service for all codes
-    let totalFeesCollectedUsd = 0
-    let totalReferrerCommissionUsd = 0
+    let totalReferrerFeeUsd = 0
 
     const referralCodesWithFees = await Promise.all(
       referralCodes.map(async (code) => {
         try {
           const feeData = await this.swapServiceClient.calculateReferralFees(code.code, startDate, endDate)
 
-          const feesCollected = parseFloat(feeData.totalFeesCollectedUsd || '0')
-          const referrerCommission = parseFloat(feeData.referrerCommissionUsd || '0')
-
-          totalFeesCollectedUsd += feesCollected
-          totalReferrerCommissionUsd += referrerCommission
+          totalReferrerFeeUsd += parseFloat(feeData.periodFeeUsd || '0')
 
           return {
             code: code.code,
@@ -252,9 +247,8 @@ export class ReferralService {
             maxUses: code.maxUses,
             expiresAt: code.expiresAt,
             swapCount: feeData.swapCount || 0,
-            swapVolumeUsd: feeData.totalSwapVolumeUsd || '0',
-            feesCollectedUsd: feeData.totalFeesCollectedUsd || '0',
-            referrerCommissionUsd: feeData.referrerCommissionUsd || '0',
+            swapVolumeUsd: feeData.periodVolumeUsd || '0',
+            referrerFeeUsd: feeData.periodFeeUsd || '0',
           }
         } catch (error) {
           this.logger.warn(`Failed to fetch fees for code ${code.code}:`, error)
@@ -267,8 +261,7 @@ export class ReferralService {
             expiresAt: code.expiresAt,
             swapCount: 0,
             swapVolumeUsd: '0',
-            feesCollectedUsd: '0',
-            referrerCommissionUsd: '0',
+            referrerFeeUsd: '0',
           }
         }
       }),
@@ -278,8 +271,7 @@ export class ReferralService {
       totalReferrals,
       activeCodesCount,
       totalCodesCount: referralCodes.length,
-      totalFeesCollectedUsd: totalFeesCollectedUsd.toFixed(2),
-      totalReferrerCommissionUsd: totalReferrerCommissionUsd.toFixed(2),
+      totalReferrerFeeUsd: totalReferrerFeeUsd.toFixed(2),
       referralCodes: referralCodesWithFees,
     }
   }

--- a/package.json
+++ b/package.json
@@ -56,6 +56,8 @@
     "@shapeshiftoss/unchained-client": "10.14.10",
     "@shapeshiftoss/unchained-pulumi": "1.0.2",
     "axios": "^1.7.4",
+    "class-transformer": "^0.5.1",
+    "class-validator": "^0.14.3",
     "dotenv": "^17.2.2",
     "p-lazy": "3.1.0",
     "protobufjs": "^7.5.4",

--- a/packages/shared-types/src/index.ts
+++ b/packages/shared-types/src/index.ts
@@ -137,3 +137,12 @@ export interface VerifySwapAffiliateDto {
   protocol: string
   txHash?: string
 }
+
+export interface Fees {
+  swapCount: number
+  periodVolumeUsd: string
+  periodFeeUsd: string
+  allTimeFeeUsd: string
+  periodStart?: string
+  periodEnd?: string
+}

--- a/packages/shared-utils/src/index.ts
+++ b/packages/shared-utils/src/index.ts
@@ -1,6 +1,7 @@
 import * as crypto from 'crypto'
 
 import { fromAccountId } from '@shapeshiftoss/caip'
+import { bnOrZero } from '@shapeshiftoss/chain-adapters'
 
 // Hash utilities
 export const hashAccountId = (accountId: string, salt?: string): string => {
@@ -33,6 +34,10 @@ export const isValidAccountId = (accountId: string): boolean => {
     return caip10Regex.test(accountId)
   }
 }
+
+// Amount utilities
+export const baseUnitToPrecision = (baseUnit: string, precision: number): string =>
+  bnOrZero(baseUnit).div(bnOrZero(10).pow(precision)).toFixed()
 
 // Date utilities
 export const formatDate = (date: Date): string => {

--- a/packages/shared-utils/src/service-clients.ts
+++ b/packages/shared-utils/src/service-clients.ts
@@ -1,7 +1,7 @@
 import type { AxiosInstance } from 'axios'
 import axios from 'axios'
 
-import type { CreateNotificationDto, Device, User } from '@shapeshift/shared-types'
+import type { CreateNotificationDto, Device, Fees, User } from '@shapeshift/shared-types'
 
 import { getRequiredEnvVar } from './index'
 
@@ -100,13 +100,6 @@ export class NotificationsServiceClient {
   }
 }
 
-interface ReferralFeeData {
-  swapCount: number
-  totalSwapVolumeUsd: string
-  totalFeesCollectedUsd: string
-  referrerCommissionUsd: string
-}
-
 export class SwapServiceClient {
   private readonly axios: AxiosInstance
 
@@ -120,13 +113,13 @@ export class SwapServiceClient {
     })
   }
 
-  async calculateReferralFees(referralCode: string, startDate?: Date, endDate?: Date): Promise<ReferralFeeData> {
+  async calculateReferralFees(referralCode: string, startDate?: Date, endDate?: Date): Promise<Fees> {
     const params = new URLSearchParams()
     if (startDate) params.append('startDate', startDate.toISOString())
     if (endDate) params.append('endDate', endDate.toISOString())
 
     const url = `/swaps/referral-fees/${referralCode}${params.toString() ? `?${params.toString()}` : ''}`
-    const response = await this.axios.get<ReferralFeeData>(url)
+    const response = await this.axios.get<Fees>(url)
     return response.data
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -5260,9 +5260,6 @@ __metadata:
     "@shapeshift/shared-types": "workspace:*"
     "@shapeshift/shared-utils": "workspace:*"
     "@types/jsonwebtoken": "npm:^9.0.10"
-    axios: "npm:^1.6.2"
-    class-transformer: "npm:^0.5.1"
-    class-validator: "npm:^0.14.3"
     jsonwebtoken: "npm:^9.0.3"
     siwe: "npm:^3.0.0"
   languageName: unknown
@@ -8368,7 +8365,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"axios@npm:1.13.2, axios@npm:^1.13.0, axios@npm:^1.6.2, axios@npm:^1.6.8, axios@npm:^1.7.4":
+"axios@npm:1.13.2, axios@npm:^1.13.0, axios@npm:^1.6.8, axios@npm:^1.7.4":
   version: 1.13.2
   resolution: "axios@npm:1.13.2"
   dependencies:
@@ -16998,6 +16995,8 @@ __metadata:
     "@types/jest": "npm:^30.0.0"
     "@types/node": "npm:^22.10.7"
     axios: "npm:^1.7.4"
+    class-transformer: "npm:^0.5.1"
+    class-validator: "npm:^0.14.3"
     dotenv: "npm:^17.2.2"
     eslint: "npm:^9.18.0"
     eslint-config-prettier: "npm:^10.0.1"


### PR DESCRIPTION
## Description

Multi-pass cleanup of `apps/swap-service/src/swaps`. No behavior changes to swap creation or status update; fee responses get a new (correct) shape and pollSwapStatus now returns proper HTTP errors for unrecoverable preconditions.

**Types & domain model**
- Extract a `Swap` domain type that narrows Prisma JSON columns to their real shapes (`SwapperSpecificMetadata`, `Asset`, `AffiliateVerificationDetails`).
- Move the fee-response type (`Fees`) into `@shapeshift/shared-types` so the swap-service server and the `SwapServiceClient` share one contract.
- Tighten `AffiliateVerificationDetails.hasAffiliate` to required (matches `SwapStatusResponse`). `toSwap` coerces malformed historical rows (`{}`) to `null` so the tightened contract holds without a data migration.

**Fee calculation**
- Unify the referral and affiliate per-swap math into a single `calculateFeeForSwap`. Prefers on-chain `actualAffiliateFeeAmount` when available; falls back to `sellUsd × verifiedBps / 10000`; back-derives volume from the inverse when only the actual fee is known.
- Fix `getAffiliateFeeRate`: returns `1` when partner's bps ≤ platform floor (was `0`, silently under-paid partners). Drops `origin` param — callers now filter `origin: 'web'` / `origin: 'api'` at the query layer.
- `aggregateFees` runs one DB query + in-memory period partition (was two overlapping queries) and only counts rows that contributed fees.
- Fix broken `SwapServiceClient.calculateReferralFees` contract: the declared shape never matched the server response, so user-service's referral stats were always reading undefined and publishing `'0'`. user-service output now exposes a single `referrerFeeUsd` / `totalReferrerFeeUsd` populated from real server data.
- Rename \"commission\" → \"fee\" throughout types, logs, and responses.

**pollSwapStatus**
- Extract swapper plumbing (env config + 9 chain-adapter asserts) into a new `swapper-config.ts`. Asserts are built once at construction time rather than per-call.
- Split the verify-and-persist block into `reconcileSwap`, returning a typed `SwapReconciliation`.
- Precondition failures now throw proper HTTP errors instead of masquerading as `status: 'PENDING'` with the real reason buried in `statusMessage`:
  - missing swap → `NotFoundException` (404)
  - missing `sellTxHash` → `BadRequestException` (400)
  - swapper not registered → `InternalServerErrorException` (500, server-config issue)
- Persist `Prisma.DbNull` (not `{}`) when reconciliation produced no affiliate details.
- Function body went from ~180 lines to ~30.

**Other**
- Validate pagination query params via `PaginationQueryDto`.
- Tighten status notification body strings.
- Restore `GET /swaps/pending` precedence over the `:swapId` wildcard.
- Drop dead helpers (`estimateAffiliateFeeAmount`, `getSwapperFeeStrategy`, `resolveSwapSellAmountUsd`).

## Testing

- [ ] Swap creation, status poll, and status update endpoints continue to work against a seeded dev DB.
- [ ] `GET /swaps/referral-fees/:code` returns the new `Fees` shape (`swapCount`, `periodVolumeUsd`, `periodFeeUsd`, `allTimeFeeUsd`, `periodStart`, `periodEnd`).
- [ ] `GET /swaps/affiliate-fees/:address` returns the same shape and only matches `origin: 'api'` swaps.
- [ ] user-service referral-stats endpoint exposes `referrerFeeUsd` / `totalReferrerFeeUsd` populated with non-zero values for referrers with attributed swaps.
- [ ] Polling a non-existent swapId returns 404 (was 200 `status: 'PENDING'`).
- [ ] Polling a swap whose swapperName has no registered swapper returns 500; polling a swap with no `sellTxHash` returns 400.
- [ ] `GET /swaps/pending` returns the pending list (not a 404 from the `:swapId` handler).
- [ ] After a poll, `affiliateVerificationDetails` is either `NULL` or a populated JSON object — never `{}`.
- [ ] Historical rows with `{}` in `affiliateVerificationDetails` surface as `null` via `getSwapById` / list endpoints.
- [ ] Manual sanity check: referral fee on a web swap with `shapeshiftBps = verifiedBps = 10` pays the referrer `sellUsd × 10 / 10000 × 0.1`; affiliate fee on an api swap with `verifiedBps = 30, shapeshiftBps = 10` pays the partner `sellUsd × 30 / 10000 × (20/30)`.