### PR TITLE
chore(swap-service): remove unused PUT status and verify-affiliate routes

### DIFF
--- a/apps/swap-service/src/swaps/swaps.controller.ts
+++ b/apps/swap-service/src/swaps/swaps.controller.ts
@@ -6,14 +6,11 @@ import {
   Param,
   ParseDatePipe,
   Post,
-  Put,
   Query,
   ValidationPipe,
 } from '@nestjs/common'
 
-import type { CreateSwapDto, UpdateSwapStatusDto, VerifySwapAffiliateDto } from '@shapeshift/shared-types'
-
-import { SwapVerificationService } from '../verification/swap-verification.service'
+import type { CreateSwapDto } from '@shapeshift/shared-types'
 
 import { SwapsService } from './swaps.service'
 import { PaginationQueryDto } from './types'
@@ -23,19 +20,11 @@ const PaginationPipe = new ValidationPipe({ transform: true, whitelist: true, fo
 
 @Controller('swaps')
 export class SwapsController {
-  constructor(
-    private swapsService: SwapsService,
-    private swapVerificationService: SwapVerificationService,
-  ) {}
+  constructor(private swapsService: SwapsService) {}
 
   @Post()
   async createSwap(@Body() data: CreateSwapDto) {
     return this.swapsService.createSwap(data)
-  }
-
-  @Put(':swapId/status')
-  async updateSwapStatus(@Param('swapId') swapId: string, @Body() data: Omit<UpdateSwapStatusDto, 'swapId'>) {
-    return this.swapsService.updateSwapStatus({ swapId, ...data })
   }
 
   @Get('pending')
@@ -76,17 +65,5 @@ export class SwapsController {
     @Query('endDate', OptionalDatePipe) endDate?: Date,
   ) {
     return this.swapsService.calculateAffiliateFees(affiliateAddress, startDate, endDate)
-  }
-
-  @Post(':swapId/verify-affiliate')
-  async verifySwapAffiliate(@Param('swapId') swapId: string, @Body() data: Omit<VerifySwapAffiliateDto, 'swapId'>) {
-    const swap = await this.swapsService.getSwapById(swapId)
-    if (!swap) throw new NotFoundException(`Swap ${swapId} not found`)
-
-    return this.swapVerificationService.verifySwap({
-      ...swap,
-      swapperName: data.swapperName || swap.swapperName,
-      sellTxHash: data.txHash || swap.sellTxHash,
-    })
   }
 }

--- a/packages/shared-types/src/index.ts
+++ b/packages/shared-types/src/index.ts
@@ -133,12 +133,6 @@ export interface SwapVerificationResult {
   error?: string
 }
 
-export interface VerifySwapAffiliateDto {
-  swapId: string
-  swapperName?: SwapperName
-  txHash?: string
-}
-
 export interface Fees {
   swapCount: number
   periodVolumeUsd: string


### PR DESCRIPTION
## Description

Removes two HTTP routes on `SwapsController` that have no callers in this repo or `shapeshift/web`:

- `PUT /swaps/:swapId/status` — status updates flow through `SwapPollingService` → `SwapsService.updateSwapStatus` in-process via DI; the HTTP surface was dead. Exposed unauthenticated state mutation.
- `POST /swaps/:swapId/verify-affiliate` — verification already runs in `SwapsService.reconcileSwap` during the polling lifecycle. Exposed unauthenticated outbound API key burn (Bebop / Chainflip / NEAR Intents / 0x proxy), partial SSRF via unvalidated `txHash` interpolation into upstream URLs, verifier confusion via `swapperName` override, and information disclosure of upstream API payloads in `details`.

Also drops the now-unused `VerifySwapAffiliateDto` from `@shapeshift/shared-types`. `UpdateSwapStatusDto` stays — it's still the parameter type for the in-process `SwapsService.updateSwapStatus` method.

If a real caller appears for either route, re-add with proper service auth.

## Testing

- [ ] swap-service builds and boots without the removed deps
- [ ] in-process flows still work: polling lifecycle persists status changes, reconcile verifies affiliates
- [ ] no external consumers regress (verified via grep across microservices and shapeshift/web)

🤖 Generated with [Claude Code](https://claude.com/claude-code)