### PR TITLE
refactor(swap-service): unify affiliate swaps with canonical Swap shape

### DIFF
--- a/apps/swap-service/src/affiliate/affiliate.controller.ts
+++ b/apps/swap-service/src/affiliate/affiliate.controller.ts
@@ -11,11 +11,12 @@ import {
   Query,
   Req,
   UseGuards,
+  ValidationPipe,
 } from '@nestjs/common'
 
 import { AffiliateService } from './affiliate.service'
 import { SiweAuthGuard, SiweRequest } from './siwe-auth.guard'
-import type { CreateAffiliateDto, UpdateAffiliateDto } from './types'
+import { AffiliateSwapsQueryDto, type CreateAffiliateDto, type UpdateAffiliateDto } from './types'
 import {
   assertAddressQuery,
   assertBpsInRange,
@@ -26,28 +27,15 @@ import {
   parseDateRange,
 } from './utils'
 
+const AffiliateSwapsQueryPipe = new ValidationPipe({ transform: true, whitelist: true, forbidNonWhitelisted: true })
+
 @Controller('v1/affiliate')
 export class AffiliateController {
   constructor(private affiliateService: AffiliateService) {}
 
   @Get('swaps')
-  async getSwaps(
-    @Query('address') address: string,
-    @Query('startDate') startDate?: string,
-    @Query('endDate') endDate?: string,
-    @Query('limit') limit?: string,
-    @Query('cursor') cursor?: string,
-  ) {
-    assertAddressQuery(address)
-
-    const { start, end } = parseDateRange(startDate, endDate)
-
-    return this.affiliateService.getAffiliateSwaps(address, {
-      startDate: start,
-      endDate: end,
-      limit: limit ? parseInt(limit, 10) : 50,
-      cursor,
-    })
+  async getSwaps(@Query(AffiliateSwapsQueryPipe) query: AffiliateSwapsQueryDto) {
+    return this.affiliateService.getAffiliateSwaps(query.address, query)
   }
 
   @Get('stats')

--- a/apps/swap-service/src/affiliate/affiliate.controller.ts
+++ b/apps/swap-service/src/affiliate/affiliate.controller.ts
@@ -11,42 +11,38 @@ import {
   Query,
   Req,
   UseGuards,
-  ValidationPipe,
 } from '@nestjs/common'
 
 import { AffiliateService } from './affiliate.service'
 import { SiweAuthGuard, SiweRequest } from './siwe-auth.guard'
-import { AffiliateSwapsQueryDto, type CreateAffiliateDto, type UpdateAffiliateDto } from './types'
 import {
-  assertAddressQuery,
-  assertBpsInRange,
-  assertEvmAddress,
-  assertOptionalEvmAddress,
-  assertPartnerCode,
-  assertSiweMatches,
-  parseDateRange,
-} from './utils'
-
-const AffiliateSwapsQueryPipe = new ValidationPipe({ transform: true, whitelist: true, forbidNonWhitelisted: true })
+  AddressQueryDto,
+  AffiliateStatsQueryDto,
+  AffiliateSwapsQueryDto,
+  ClaimPartnerCodeDto,
+  CreateAffiliateDto,
+  UpdateAffiliateDto,
+} from './types'
+import { assertSiweMatches } from './utils'
 
 @Controller('v1/affiliate')
 export class AffiliateController {
   constructor(private affiliateService: AffiliateService) {}
 
   @Get('swaps')
-  async getSwaps(@Query(AffiliateSwapsQueryPipe) query: AffiliateSwapsQueryDto) {
+  async getSwaps(@Query() query: AffiliateSwapsQueryDto) {
     return this.affiliateService.getAffiliateSwaps(query.address, query)
   }
 
   @Get('stats')
-  async getStats(
-    @Query('address') address: string,
-    @Query('startDate') startDate?: string,
-    @Query('endDate') endDate?: string,
-  ) {
-    assertAddressQuery(address)
-    const { start, end } = parseDateRange(startDate, endDate)
-    return this.affiliateService.getAffiliateStats(address, start, end)
+  async getStats(@Query() query: AffiliateStatsQueryDto) {
+    return this.affiliateService.getAffiliateStats(query.address, query.startDate, query.endDate)
+  }
+
+  @Get('lookup/bps')
+  async lookupBps(@Query() query: AddressQueryDto) {
+    const bps = await this.affiliateService.lookupAffiliateBps(query.address)
+    return { bps }
   }
 
   @Get(':address')
@@ -59,12 +55,7 @@ export class AffiliateController {
   @UseGuards(SiweAuthGuard)
   @Post()
   async createAffiliate(@Req() req: SiweRequest, @Body() data: CreateAffiliateDto) {
-    assertBpsInRange(data.bps)
-    assertEvmAddress(data.walletAddress, 'wallet address')
-    assertOptionalEvmAddress(data.receiveAddress, 'receive address')
     assertSiweMatches(req, data.walletAddress, 'Authenticated address does not match walletAddress')
-
-    if (data.partnerCode) assertPartnerCode(data.partnerCode)
 
     try {
       return await this.affiliateService.createAffiliate(data)
@@ -79,8 +70,6 @@ export class AffiliateController {
   @UseGuards(SiweAuthGuard)
   @Patch(':address')
   async updateAffiliate(@Req() req: SiweRequest, @Param('address') address: string, @Body() data: UpdateAffiliateDto) {
-    assertBpsInRange(data.bps)
-    assertOptionalEvmAddress(data.receiveAddress, 'receive address')
     assertSiweMatches(req, address, 'Authenticated address does not match target address')
 
     return this.affiliateService.updateAffiliate(address, data)
@@ -88,9 +77,7 @@ export class AffiliateController {
 
   @UseGuards(SiweAuthGuard)
   @Post('claim-code')
-  async claimPartnerCode(@Req() req: SiweRequest, @Body() data: { walletAddress: string; partnerCode: string }) {
-    assertPartnerCode(data.partnerCode)
-    assertEvmAddress(data.walletAddress, 'wallet address')
+  async claimPartnerCode(@Req() req: SiweRequest, @Body() data: ClaimPartnerCodeDto) {
     assertSiweMatches(req, data.walletAddress, 'Authenticated address does not match walletAddress')
 
     try {
@@ -106,13 +93,6 @@ export class AffiliateController {
       }
       throw error
     }
-  }
-
-  @Get('lookup/bps')
-  async lookupBps(@Query('address') address: string) {
-    assertAddressQuery(address)
-    const bps = await this.affiliateService.lookupAffiliateBps(address)
-    return { bps }
   }
 }
 

--- a/apps/swap-service/src/affiliate/affiliate.service.ts
+++ b/apps/swap-service/src/affiliate/affiliate.service.ts
@@ -108,7 +108,14 @@ export class AffiliateService {
       ...swapCursorArgs(limit, cursor),
       where: {
         affiliateAddress,
-        ...(startDate && endDate && { createdAt: { gte: startDate, lte: endDate } }),
+        ...(startDate || endDate
+          ? {
+              createdAt: {
+                ...(startDate && { gte: startDate }),
+                ...(endDate && { lte: endDate }),
+              },
+            }
+          : {}),
       },
     })
 

--- a/apps/swap-service/src/affiliate/affiliate.service.ts
+++ b/apps/swap-service/src/affiliate/affiliate.service.ts
@@ -2,16 +2,12 @@ import { Injectable, Logger, NotFoundException } from '@nestjs/common'
 import { Affiliate, Prisma } from '@prisma/client'
 
 import { PrismaService } from '../prisma/prisma.service'
+import { PaginatedSwaps } from '../swaps/types'
+import { toSwap } from '../swaps/utils'
 import { getNextCursor, swapCursorArgs } from '../utils/pagination'
 
-import type {
-  AffiliateStatsResult,
-  AffiliateSwapsResult,
-  CreateAffiliateDto,
-  GetAffiliateSwapsOptions,
-  UpdateAffiliateDto,
-} from './types'
-import { calculateAffiliateFeeUsd, RESERVED_PARTNER_CODES } from './utils'
+import type { AffiliateStatsResult, AffiliateSwapsQueryDto, CreateAffiliateDto, UpdateAffiliateDto } from './types'
+import { RESERVED_PARTNER_CODES } from './utils'
 
 @Injectable()
 export class AffiliateService {
@@ -105,11 +101,8 @@ export class AffiliateService {
     }
   }
 
-  async getAffiliateSwaps(
-    affiliateAddress: string,
-    options: GetAffiliateSwapsOptions = {},
-  ): Promise<AffiliateSwapsResult> {
-    const { startDate, endDate, limit = 50, cursor } = options
+  async getAffiliateSwaps(affiliateAddress: string, options: AffiliateSwapsQueryDto): Promise<PaginatedSwaps> {
+    const { startDate, endDate, limit, cursor } = options
 
     const items = await this.prisma.swap.findMany({
       ...swapCursorArgs(limit, cursor),
@@ -117,31 +110,10 @@ export class AffiliateService {
         affiliateAddress,
         ...(startDate && endDate && { createdAt: { gte: startDate, lte: endDate } }),
       },
-      select: {
-        swapId: true,
-        status: true,
-        sellAsset: true,
-        buyAsset: true,
-        sellAmountCryptoBaseUnit: true,
-        expectedBuyAmountCryptoBaseUnit: true,
-        actualBuyAmountCryptoBaseUnit: true,
-        sellAmountUsd: true,
-        buyAssetUsd: true,
-        affiliateBps: true,
-        shapeshiftBps: true,
-        swapperName: true,
-        sellTxHash: true,
-        buyTxHash: true,
-        isAffiliateVerified: true,
-        createdAt: true,
-      },
     })
 
     return {
-      swaps: items.map((swap) => ({
-        ...swap,
-        affiliateFeeUsd: calculateAffiliateFeeUsd(swap.sellAmountUsd, swap.affiliateBps),
-      })),
+      swaps: items.map(toSwap),
       nextCursor: getNextCursor(items, limit),
     }
   }

--- a/apps/swap-service/src/affiliate/types.ts
+++ b/apps/swap-service/src/affiliate/types.ts
@@ -1,12 +1,33 @@
 import { Type } from 'class-transformer'
-import { IsDate, IsEthereumAddress, IsOptional } from 'class-validator'
+import { IsBoolean, IsDate, IsEthereumAddress, IsInt, IsOptional, Matches, Max, Min } from 'class-validator'
 
 import { PaginationQueryDto } from '../swaps/types'
+
+import { PARTNER_CODE_REGEX } from './utils'
+
+const PARTNER_CODE_MESSAGE = 'Partner code must be 3-32 alphanumeric characters or hyphens'
 
 export interface AffiliateStatsResult {
   totalSwaps: number
   totalVolumeUsd: string
   totalFeesEarnedUsd: string
+}
+
+export class AddressQueryDto {
+  @IsEthereumAddress()
+  address: string
+}
+
+export class AffiliateStatsQueryDto extends AddressQueryDto {
+  @IsOptional()
+  @Type(() => Date)
+  @IsDate()
+  startDate?: Date
+
+  @IsOptional()
+  @Type(() => Date)
+  @IsDate()
+  endDate?: Date
 }
 
 export class AffiliateSwapsQueryDto extends PaginationQueryDto {
@@ -24,15 +45,45 @@ export class AffiliateSwapsQueryDto extends PaginationQueryDto {
   endDate?: Date
 }
 
-export interface CreateAffiliateDto {
+export class CreateAffiliateDto {
+  @IsEthereumAddress()
   walletAddress: string
+
+  @IsOptional()
+  @IsEthereumAddress()
   receiveAddress?: string
+
+  @IsOptional()
+  @Matches(PARTNER_CODE_REGEX, { message: PARTNER_CODE_MESSAGE })
   partnerCode?: string
+
+  @IsOptional()
+  @IsInt()
+  @Min(0)
+  @Max(1000)
   bps?: number
 }
 
-export interface UpdateAffiliateDto {
+export class UpdateAffiliateDto {
+  @IsOptional()
+  @IsEthereumAddress()
   receiveAddress?: string
+
+  @IsOptional()
+  @IsInt()
+  @Min(0)
+  @Max(1000)
   bps?: number
+
+  @IsOptional()
+  @IsBoolean()
   isActive?: boolean
+}
+
+export class ClaimPartnerCodeDto {
+  @IsEthereumAddress()
+  walletAddress: string
+
+  @Matches(PARTNER_CODE_REGEX, { message: PARTNER_CODE_MESSAGE })
+  partnerCode: string
 }

--- a/apps/swap-service/src/affiliate/types.ts
+++ b/apps/swap-service/src/affiliate/types.ts
@@ -1,39 +1,24 @@
+import { Type } from 'class-transformer'
+import { IsDate, IsOptional } from 'class-validator'
+
+import { PaginationQueryDto } from '../swaps/types'
+
 export interface AffiliateStatsResult {
   totalSwaps: number
   totalVolumeUsd: string
   totalFeesEarnedUsd: string
 }
 
-export interface AffiliateSwapItem {
-  swapId: string
-  status: string
-  sellAsset: unknown
-  buyAsset: unknown
-  sellAmountCryptoBaseUnit: string
-  expectedBuyAmountCryptoBaseUnit: string
-  actualBuyAmountCryptoBaseUnit: string | null
-  sellAmountUsd: string | null
-  buyAssetUsd: string | null
-  affiliateBps: number | null
-  shapeshiftBps: number
-  affiliateFeeUsd: string | null
-  swapperName: string
-  sellTxHash: string | null
-  buyTxHash: string | null
-  isAffiliateVerified: boolean | null
-  createdAt: Date
-}
-
-export interface AffiliateSwapsResult {
-  swaps: AffiliateSwapItem[]
-  nextCursor: string | null
-}
-
-export interface GetAffiliateSwapsOptions {
+export class AffiliateSwapsQueryDto extends PaginationQueryDto {
+  @IsOptional()
+  @Type(() => Date)
+  @IsDate()
   startDate?: Date
+
+  @IsOptional()
+  @Type(() => Date)
+  @IsDate()
   endDate?: Date
-  limit?: number
-  cursor?: string
 }
 
 export interface CreateAffiliateDto {

--- a/apps/swap-service/src/affiliate/types.ts
+++ b/apps/swap-service/src/affiliate/types.ts
@@ -1,5 +1,5 @@
 import { Type } from 'class-transformer'
-import { IsDate, IsOptional } from 'class-validator'
+import { IsDate, IsEthereumAddress, IsOptional } from 'class-validator'
 
 import { PaginationQueryDto } from '../swaps/types'
 
@@ -10,6 +10,9 @@ export interface AffiliateStatsResult {
 }
 
 export class AffiliateSwapsQueryDto extends PaginationQueryDto {
+  @IsEthereumAddress()
+  address: string
+
   @IsOptional()
   @Type(() => Date)
   @IsDate()

--- a/apps/swap-service/src/affiliate/utils.ts
+++ b/apps/swap-service/src/affiliate/utils.ts
@@ -38,8 +38,3 @@ export function parseDateRange(startDate?: string, endDate?: string): { start?: 
     end: endDate ? new Date(endDate) : undefined,
   }
 }
-
-export function calculateAffiliateFeeUsd(sellAmountUsd: string | null, affiliateBps: number | null): string | null {
-  if (!sellAmountUsd || affiliateBps == null) return null
-  return ((parseFloat(sellAmountUsd) * affiliateBps) / 10000).toFixed(2)
-}

--- a/apps/swap-service/src/affiliate/utils.ts
+++ b/apps/swap-service/src/affiliate/utils.ts
@@ -1,40 +1,10 @@
-import { BadRequestException, ForbiddenException } from '@nestjs/common'
+import { ForbiddenException } from '@nestjs/common'
 
 import type { SiweRequest } from './siwe-auth.guard'
 
-export const EVM_ADDRESS_REGEX = /^0x[a-fA-F0-9]{40}$/
 export const PARTNER_CODE_REGEX = /^[a-zA-Z0-9-]{3,32}$/
 export const RESERVED_PARTNER_CODES = ['ss', 'admin', 'api', 'test', 'demo']
 
-export function assertAddressQuery(address: string | undefined): asserts address is string {
-  if (!address) throw new BadRequestException('address query parameter is required')
-}
-
-export function assertEvmAddress(address: string | undefined, label: string): void {
-  if (!address || !EVM_ADDRESS_REGEX.test(address)) throw new BadRequestException(`Invalid ${label}`)
-}
-
-export function assertOptionalEvmAddress(address: string | undefined, label: string): void {
-  if (address && !EVM_ADDRESS_REGEX.test(address)) throw new BadRequestException(`Invalid ${label}`)
-}
-
-export function assertBpsInRange(bps: number | undefined): void {
-  if (bps !== undefined && (bps < 0 || bps > 1000)) throw new BadRequestException('BPS must be between 0 and 1000')
-}
-
-export function assertPartnerCode(partnerCode: string): void {
-  if (!PARTNER_CODE_REGEX.test(partnerCode)) {
-    throw new BadRequestException('Partner code must be 3-32 alphanumeric characters or hyphens')
-  }
-}
-
 export function assertSiweMatches(req: SiweRequest, target: string, message: string): void {
   if (req.siweAddress !== target.toLowerCase()) throw new ForbiddenException(message)
-}
-
-export function parseDateRange(startDate?: string, endDate?: string): { start?: Date; end?: Date } {
-  return {
-    start: startDate ? new Date(startDate) : undefined,
-    end: endDate ? new Date(endDate) : undefined,
-  }
 }

--- a/apps/swap-service/src/main.ts
+++ b/apps/swap-service/src/main.ts
@@ -1,3 +1,4 @@
+import { ValidationPipe } from '@nestjs/common'
 import { NestFactory } from '@nestjs/core'
 import type { Response } from 'express'
 
@@ -7,6 +8,8 @@ import { ChainAdapterInitService } from './lib/chain-adapter-init.service'
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule)
+
+  app.useGlobalPipes(new ValidationPipe({ transform: true, whitelist: true, forbidNonWhitelisted: true }))
 
   // Initialize chain adapters
   const chainAdapterInitService = app.get(ChainAdapterInitService)
@@ -22,7 +25,6 @@ async function bootstrap() {
     res.status(200).json({ status: 'ok' })
   })
 
-  // TODO: Add ValidationPipe when class-validator resolves properly in Yarn workspaces
   app.enableShutdownHooks()
 
   const port = env.PORT || 3001

--- a/apps/swap-service/src/swaps/swaps.controller.ts
+++ b/apps/swap-service/src/swaps/swaps.controller.ts
@@ -1,14 +1,4 @@
-import {
-  Body,
-  Controller,
-  Get,
-  NotFoundException,
-  Param,
-  ParseDatePipe,
-  Post,
-  Query,
-  ValidationPipe,
-} from '@nestjs/common'
+import { Body, Controller, Get, NotFoundException, Param, ParseDatePipe, Post, Query } from '@nestjs/common'
 
 import type { CreateSwapDto } from '@shapeshift/shared-types'
 
@@ -16,7 +6,6 @@ import { SwapsService } from './swaps.service'
 import { PaginationQueryDto } from './types'
 
 const OptionalDatePipe = new ParseDatePipe({ optional: true })
-const PaginationPipe = new ValidationPipe({ transform: true, whitelist: true, forbidNonWhitelisted: true })
 
 @Controller('swaps')
 export class SwapsController {
@@ -40,12 +29,12 @@ export class SwapsController {
   }
 
   @Get('user/:userId')
-  async getSwapsByUser(@Param('userId') userId: string, @Query(PaginationPipe) query: PaginationQueryDto) {
+  async getSwapsByUser(@Param('userId') userId: string, @Query() query: PaginationQueryDto) {
     return this.swapsService.getSwapsByUser(userId, query)
   }
 
   @Get('account/:accountId')
-  async getSwapsByAccountId(@Param('accountId') accountId: string, @Query(PaginationPipe) query: PaginationQueryDto) {
+  async getSwapsByAccountId(@Param('accountId') accountId: string, @Query() query: PaginationQueryDto) {
     return this.swapsService.getSwapsByAccountId(accountId, query)
   }
 

--- a/apps/swap-service/src/swaps/swaps.service.ts
+++ b/apps/swap-service/src/swaps/swaps.service.ts
@@ -222,7 +222,7 @@ export class SwapsService {
 
     const rows = await this.prisma.swap.findMany({ where, ...swapCursorArgs(limit, cursor) })
 
-    return { items: rows.map(toSwap), nextCursor: getNextCursor(rows, limit) }
+    return { swaps: rows.map(toSwap), nextCursor: getNextCursor(rows, limit) }
   }
 
   async getPendingSwaps(): Promise<Swap[]> {

--- a/apps/swap-service/src/swaps/types.ts
+++ b/apps/swap-service/src/swaps/types.ts
@@ -45,7 +45,7 @@ export type AggregateFeesParams = {
 }
 
 export type PaginatedSwaps = {
-  items: Swap[]
+  swaps: Swap[]
   nextCursor: string | null
 }
 

--- a/apps/swap-service/src/verification/swap-verification.service.ts
+++ b/apps/swap-service/src/verification/swap-verification.service.ts
@@ -199,6 +199,7 @@ export class SwapVerificationService {
       return isNative ? `eip155:${chainId}/slip44:60` : `eip155:${chainId}/erc20:${address}`
     })()
 
+    // TODO: actualAffiliateFeeUsd, actualAffiliateFeeAmountUsd
     const result: SwapVerificationResult = {
       isVerified: true,
       hasAffiliate: Boolean(shapeshiftFee),

--- a/apps/swap-service/src/websocket/websocket.gateway.ts
+++ b/apps/swap-service/src/websocket/websocket.gateway.ts
@@ -50,12 +50,12 @@ export class WebsocketGateway implements OnGatewayConnection, OnGatewayDisconnec
     if (!client.userId) return { error: 'Not authenticated' }
 
     try {
-      const { items, nextCursor } = await this.swapsService.getSwapsByUser(client.userId, {
+      const { swaps, nextCursor } = await this.swapsService.getSwapsByUser(client.userId, {
         limit: data.limit || 50,
         cursor: data.cursor,
       })
 
-      return { success: true, swaps: items, nextCursor }
+      return { success: true, swaps, nextCursor }
     } catch (error) {
       this.logger.error('Failed to get swaps', error)
       return { error: 'Failed to get swaps' }


### PR DESCRIPTION
## Description

- Drop `AffiliateSwapItem` / `AffiliateSwapsResult` and the `calculateAffiliateFeeUsd` helper. `getAffiliateSwaps` now returns `PaginatedSwaps` and maps rows through `toSwap`, so affiliates see the same canonical `Swap` shape used everywhere else in the service.
- Rename `PaginatedSwaps.items` to `swaps` and update the websocket gateway accordingly.
- Convert `GetAffiliateSwapsOptions` to a `AffiliateSwapsQueryDto` class extending `PaginationQueryDto`, with validated optional `startDate` / `endDate` fields.
- Add a TODO in `swap-verification.service.ts` for follow-up `actualAffiliateFeeUsd` / `actualAffiliateFeeAmountUsd` capture.

## Testing

- [ ] Existing affiliate-swaps consumers receive the canonical `Swap` shape (check FE expectations on the renamed `swaps` field).
- [ ] `AffiliateSwapsQueryDto` validates `startDate` / `endDate` and rejects invalid dates when wired to a controller.
- [ ] Websocket `getSwaps` flow still returns `{ success, swaps, nextCursor }`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Affiliate swaps query now supports optional date range filtering with `startDate` and `endDate` parameters.

* **Refactor**
  * Standardized paginated response structure across swap APIs for consistency.
  * Refactored affiliate swaps retrieval logic to use simplified query parameters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->