### PR TITLE
chore(swap-service): use relayTokenToAssetId from @shapeshiftoss/swapper

### DIFF
--- a/apps/swap-service/src/verification/__tests__/setup.ts
+++ b/apps/swap-service/src/verification/__tests__/setup.ts
@@ -60,4 +60,10 @@ jest.mock('@shapeshiftoss/swapper', () => ({
   },
   assertGetCowNetwork: jest.fn(),
   getTreasuryAddressFromChainId: jest.fn(),
+  relayTokenToAssetId: (token: { chainId: number; address: string }) => {
+    const isNative = token.address.toLowerCase() === '0x0000000000000000000000000000000000000000'
+    return isNative
+      ? `eip155:${token.chainId}/slip44:60`
+      : `eip155:${token.chainId}/erc20:${token.address.toLowerCase()}`
+  },
 }))

--- a/apps/swap-service/src/verification/swap-verification.service.ts
+++ b/apps/swap-service/src/verification/swap-verification.service.ts
@@ -4,7 +4,12 @@ import { Injectable, Logger } from '@nestjs/common'
 import { firstValueFrom } from 'rxjs'
 
 import { SwapVerificationResult } from '@shapeshift/shared-types'
-import { assertGetCowNetwork, getTreasuryAddressFromChainId, SwapperName } from '@shapeshiftoss/swapper'
+import {
+  assertGetCowNetwork,
+  getTreasuryAddressFromChainId,
+  relayTokenToAssetId,
+  SwapperName,
+} from '@shapeshiftoss/swapper'
 
 import { env } from '../env'
 import type { Swap } from '../swaps/types'
@@ -179,18 +184,17 @@ export class SwapVerificationService {
 
     // Relay's appFeeCurrencyObject is the source of truth for which asset the affiliate fee was paid in —
     // it can be the sell asset, the buy asset, or neither, depending on the route.
-    // TODO: replace with `relayTokenToAssetId` from `@shapeshiftoss/swapper`
     const actualAffiliateFeeAssetId = (() => {
       if (!shapeshiftFee) return
 
-      const chainId = request.data.appFeeCurrencyObject?.chainId
-      const address = request.data.appFeeCurrencyObject?.address?.toLowerCase()
+      const currency = request.data.appFeeCurrencyObject
+      if (!currency) return
 
-      if (!chainId || !address) return
-
-      const isNative = address === '0x0000000000000000000000000000000000000000'
-
-      return isNative ? `eip155:${chainId}/slip44:60` : `eip155:${chainId}/erc20:${address}`
+      try {
+        return relayTokenToAssetId(currency)
+      } catch {
+        return
+      }
     })()
 
     const actualAffiliateFeeUsd = await (async () => {

--- a/apps/swap-service/src/verification/types.ts
+++ b/apps/swap-service/src/verification/types.ts
@@ -57,11 +57,11 @@ interface RelayAppFee {
 }
 
 interface RelayToken {
-  chainId?: number
-  address?: string
-  symbol?: string
-  name?: string
-  decimals?: number
+  chainId: number
+  address: string
+  symbol: string
+  name: string
+  decimals: number
 }
 
 interface RelayCurrencyAmount {

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "@pulumi/pulumi": "3.160.0",
     "@shapeshiftoss/caip": "8.16.7",
     "@shapeshiftoss/chain-adapters": "11.3.9",
-    "@shapeshiftoss/swapper": "17.7.0",
+    "@shapeshiftoss/swapper": "17.7.3",
     "@shapeshiftoss/types": "8.6.7",
     "@shapeshiftoss/unchained-client": "10.14.10",
     "@shapeshiftoss/unchained-pulumi": "1.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5473,9 +5473,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@shapeshiftoss/swapper@npm:17.7.0":
-  version: 17.7.0
-  resolution: "@shapeshiftoss/swapper@npm:17.7.0"
+"@shapeshiftoss/swapper@npm:17.7.3":
+  version: 17.7.3
+  resolution: "@shapeshiftoss/swapper@npm:17.7.3"
   dependencies:
     "@arbitrum/sdk": "npm:^4.0.1"
     "@avnu/avnu-sdk": "npm:^4.0.1"
@@ -5512,7 +5512,7 @@ __metadata:
     retry-axios: "npm:^2.6.0"
     uuid: "npm:^9.0.0"
     viem: "npm:2.43.5"
-  checksum: 10/488518817eec6f91b5c8d7f712a7d5e5c815f8caa6439757faea00b9456056fb309b4d7e4c2eb92ebf90f989093f7e34b56affaaaeffd59ce878b13dc604933f
+  checksum: 10/8c91468552e92bd64efa4a230c1c1c80b3dcabaccb787ce9f52cb4de76f918e9e284695bd1a0411d5e5ded2e4ce630884277388ac62bee08a449a0a8e4506926
   languageName: node
   linkType: hard
 
@@ -16987,7 +16987,7 @@ __metadata:
     "@pulumi/pulumi": "npm:3.160.0"
     "@shapeshiftoss/caip": "npm:8.16.7"
     "@shapeshiftoss/chain-adapters": "npm:11.3.9"
-    "@shapeshiftoss/swapper": "npm:17.7.0"
+    "@shapeshiftoss/swapper": "npm:17.7.3"
     "@shapeshiftoss/types": "npm:8.6.7"
     "@shapeshiftoss/unchained-client": "npm:10.14.10"
     "@shapeshiftoss/unchained-pulumi": "npm:1.0.2"


### PR DESCRIPTION
## Description

Replaces the inline `appFeeCurrencyObject` → `AssetId` construction in the Relay verifier with the canonical `relayTokenToAssetId` helper now exported from `@shapeshiftoss/swapper` (bumped 17.7.0 → 17.7.3). The helper correctly handles non-EVM chains (BTC/Solana/Tron) and Relay's numeric-chainId mapping — both of which the inline implementation got wrong.

Also adds `relayTokenToAssetId` to the test-side mock of `@shapeshiftoss/swapper` in `verification/__tests__/setup.ts` and tightens the local `RelayToken` interface to non-optional fields (matching the package contract).

## Testing

- [ ] `cd apps/swap-service && npx jest src/verification/__tests__/relay.test.ts` — existing relay tests still pass (native ETH, ERC20 USDT, missing currency cases)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced error handling in swap verification for affiliate fee processing.

* **Chores**
  * Updated swap service dependency version.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/shapeshift/microservices/pull/40?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->