### PR TITLE
feat(swap-service): stable partner attribution via partnerCode

### DIFF
--- a/apps/swap-service/src/affiliate/__tests__/affiliate.service.test.ts
+++ b/apps/swap-service/src/affiliate/__tests__/affiliate.service.test.ts
@@ -8,13 +8,14 @@ type MockAffiliateDelegate = {
   create: jest.Mock
 }
 
-const makePrismaMock = (overrides?: Partial<MockAffiliateDelegate>): PrismaService => {
+const makePrismaMock = (overrides?: Partial<MockAffiliateDelegate>, swapFindMany?: jest.Mock): PrismaService => {
   const affiliate: MockAffiliateDelegate = {
     findUnique: jest.fn().mockResolvedValue(null),
     create: jest.fn(),
     ...overrides,
   }
-  return { affiliate } as unknown as PrismaService
+  const swap = { findMany: swapFindMany ?? jest.fn().mockResolvedValue([]) }
+  return { affiliate, swap } as unknown as PrismaService
 }
 
 const baseRow = (overrides?: Partial<Affiliate>): Affiliate => ({
@@ -85,5 +86,67 @@ describe('AffiliateService.createAffiliate', () => {
     await expect(service.createAffiliate({ walletAddress: wallet, partnerCode: 'goodcode', bps: 60 })).rejects.toThrow(
       /taken/,
     )
+  })
+})
+
+describe('AffiliateService attribution reads', () => {
+  const address = '0x1111111111111111111111111111111111111111'
+
+  // Pull the `where` from the first prisma.swap.findMany call as a typed object so the
+  // assertions below don't trip the no-unsafe-any lint rules on jest's `any`-typed calls.
+  const whereOfFirstCall = (findMany: jest.Mock): Record<string, unknown> => {
+    const [[args]] = findMany.mock.calls as Array<[{ where: Record<string, unknown> }]>
+    return args.where
+  }
+
+  it('getAffiliateStatsByAddress filters through the affiliate relation, never partnerAddress', async () => {
+    const findMany = jest.fn().mockResolvedValue([])
+    const service = new AffiliateService(makePrismaMock(undefined, findMany))
+
+    await service.getAffiliateStatsByAddress(address, {})
+
+    const where = whereOfFirstCall(findMany)
+    expect(where).toMatchObject({
+      affiliate: { OR: [{ walletAddress: address }, { receiveAddress: address }] },
+    })
+    expect(where).not.toHaveProperty('partnerAddress')
+  })
+
+  it('getAffiliateSwapsByAddress filters through the affiliate relation, never partnerAddress', async () => {
+    const findMany = jest.fn().mockResolvedValue([])
+    const service = new AffiliateService(makePrismaMock(undefined, findMany))
+
+    await service.getAffiliateSwapsByAddress(address, { limit: 50 })
+
+    const where = whereOfFirstCall(findMany)
+    expect(where).toMatchObject({
+      affiliate: { OR: [{ walletAddress: address }, { receiveAddress: address }] },
+    })
+    expect(where).not.toHaveProperty('partnerAddress')
+  })
+
+  it('getAffiliateSwapsByPartnerCode filters directly on partnerCode, with no join or address', async () => {
+    const findMany = jest.fn().mockResolvedValue([])
+    const service = new AffiliateService(makePrismaMock(undefined, findMany))
+
+    await service.getAffiliateSwapsByPartnerCode('goodcode', { limit: 50 })
+
+    const where = whereOfFirstCall(findMany)
+    expect(where).toMatchObject({ partnerCode: 'goodcode' })
+    expect(where).not.toHaveProperty('affiliate')
+    expect(where).not.toHaveProperty('partnerAddress')
+  })
+
+  it('getAffiliateStatsByPartnerCode filters directly on partnerCode, with no join or address', async () => {
+    const findMany = jest.fn().mockResolvedValue([])
+    const service = new AffiliateService(makePrismaMock(undefined, findMany))
+
+    const result = await service.getAffiliateStatsByPartnerCode('goodcode', {})
+
+    const where = whereOfFirstCall(findMany)
+    expect(where).toMatchObject({ partnerCode: 'goodcode', status: 'SUCCESS', isAffiliateVerified: true })
+    expect(where).not.toHaveProperty('affiliate')
+    expect(where).not.toHaveProperty('partnerAddress')
+    expect(result).toEqual({ totalSwaps: 0, totalVolumeUsd: '0.00', totalFeesEarnedUsd: '0.00' })
   })
 })

--- a/apps/swap-service/src/affiliate/affiliate.controller.ts
+++ b/apps/swap-service/src/affiliate/affiliate.controller.ts
@@ -32,12 +32,16 @@ export class AffiliateController {
 
   @Get('swaps')
   async getSwaps(@Query() query: AffiliateSwapsQueryDto) {
-    return this.affiliateService.getAffiliateSwaps(query.address, query)
+    if (query.partnerCode) return this.affiliateService.getAffiliateSwapsByPartnerCode(query.partnerCode, query)
+    if (query.address) return this.affiliateService.getAffiliateSwapsByAddress(query.address, query)
+    throw new BadRequestException('partnerCode or address is required')
   }
 
   @Get('stats')
   async getStats(@Query() query: AffiliateStatsQueryDto) {
-    return this.affiliateService.getAffiliateStats(query.address, query)
+    if (query.partnerCode) return this.affiliateService.getAffiliateStatsByPartnerCode(query.partnerCode, query)
+    if (query.address) return this.affiliateService.getAffiliateStatsByAddress(query.address, query)
+    throw new BadRequestException('partnerCode or address is required')
   }
 
   @Get(':address')

--- a/apps/swap-service/src/affiliate/affiliate.service.ts
+++ b/apps/swap-service/src/affiliate/affiliate.service.ts
@@ -64,12 +64,12 @@ export class AffiliateService {
     return this.prisma.affiliate.update({ where: { walletAddress }, data: updateData })
   }
 
-  async getAffiliateStats(address: string, options: AffiliateStatsQueryDto): Promise<AffiliateStatsResult> {
+  async getAffiliateStatsByAddress(address: string, options: AffiliateStatsQueryDto): Promise<AffiliateStatsResult> {
     const { startDate, endDate } = options
 
     const items = await this.prisma.swap.findMany({
       where: {
-        partnerAddress: address,
+        affiliate: { OR: [{ walletAddress: address }, { receiveAddress: address }] },
         status: 'SUCCESS',
         isAffiliateVerified: true,
         ...(startDate || endDate
@@ -107,13 +107,86 @@ export class AffiliateService {
     }
   }
 
-  async getAffiliateSwaps(address: string, options: AffiliateSwapsQueryDto): Promise<PaginatedSwaps> {
+  async getAffiliateStatsByPartnerCode(
+    partnerCode: string,
+    options: { startDate?: Date; endDate?: Date },
+  ): Promise<AffiliateStatsResult> {
+    const { startDate, endDate } = options
+
+    const items = await this.prisma.swap.findMany({
+      where: {
+        partnerCode,
+        status: 'SUCCESS',
+        isAffiliateVerified: true,
+        ...(startDate || endDate
+          ? {
+              createdAt: {
+                ...(startDate && { gte: startDate }),
+                ...(endDate && { lte: endDate }),
+              },
+            }
+          : {}),
+      },
+    })
+
+    let totalSwaps = 0
+    let totalVolumeUsd = 0
+    let totalFeesEarnedUsd = 0
+
+    for (const item of items) {
+      const swap = toSwap(item)
+
+      const fee = calculateFeeForSwap(swap)
+      if (!fee) continue
+
+      const rate = getPartnerFeeRate(fee.verifiedBps, swap.partnerBps)
+
+      totalSwaps++
+      totalVolumeUsd += fee.volumeUsd
+      totalFeesEarnedUsd += fee.feeUsd * rate
+    }
+
+    return {
+      totalSwaps,
+      totalVolumeUsd: totalVolumeUsd.toFixed(2),
+      totalFeesEarnedUsd: totalFeesEarnedUsd.toFixed(2),
+    }
+  }
+
+  async getAffiliateSwapsByAddress(address: string, options: AffiliateSwapsQueryDto): Promise<PaginatedSwaps> {
     const { startDate, endDate, limit, cursor } = options
 
     const items = await this.prisma.swap.findMany({
       ...swapCursorArgs(limit, cursor),
       where: {
-        partnerAddress: address,
+        affiliate: { OR: [{ walletAddress: address }, { receiveAddress: address }] },
+        ...(startDate || endDate
+          ? {
+              createdAt: {
+                ...(startDate && { gte: startDate }),
+                ...(endDate && { lte: endDate }),
+              },
+            }
+          : {}),
+      },
+    })
+
+    return {
+      swaps: items.map(toSwap),
+      nextCursor: getNextCursor(items, limit),
+    }
+  }
+
+  async getAffiliateSwapsByPartnerCode(
+    partnerCode: string,
+    options: { startDate?: Date; endDate?: Date; limit: number; cursor?: string },
+  ): Promise<PaginatedSwaps> {
+    const { startDate, endDate, limit, cursor } = options
+
+    const items = await this.prisma.swap.findMany({
+      ...swapCursorArgs(limit, cursor),
+      where: {
+        partnerCode,
         ...(startDate || endDate
           ? {
               createdAt: {

--- a/apps/swap-service/src/affiliate/types.ts
+++ b/apps/swap-service/src/affiliate/types.ts
@@ -13,12 +13,15 @@ export interface AffiliateStatsResult {
   totalFeesEarnedUsd: string
 }
 
-export class AddressQueryDto {
+export class AffiliateStatsQueryDto {
+  @IsOptional()
   @IsEthereumAddress()
-  address: string
-}
+  address?: string
 
-export class AffiliateStatsQueryDto extends AddressQueryDto {
+  @IsOptional()
+  @Matches(PARTNER_CODE_REGEX, { message: PARTNER_CODE_MESSAGE })
+  partnerCode?: string
+
   @IsOptional()
   @Type(() => Date)
   @IsDate()
@@ -31,8 +34,13 @@ export class AffiliateStatsQueryDto extends AddressQueryDto {
 }
 
 export class AffiliateSwapsQueryDto extends PaginationQueryDto {
+  @IsOptional()
   @IsEthereumAddress()
-  address: string
+  address?: string
+
+  @IsOptional()
+  @Matches(PARTNER_CODE_REGEX, { message: PARTNER_CODE_MESSAGE })
+  partnerCode?: string
 
   @IsOptional()
   @Type(() => Date)

--- a/apps/swap-service/src/swaps/swaps.controller.ts
+++ b/apps/swap-service/src/swaps/swaps.controller.ts
@@ -42,12 +42,12 @@ export class SwapsController {
     return this.swapsService.calculateReferralFees(referralCode, startDate, endDate)
   }
 
-  @Get('affiliate-fees/:address')
+  @Get('affiliate-fees/:partnerCode')
   async getAffiliateFees(
-    @Param('address') address: string,
+    @Param('partnerCode') partnerCode: string,
     @Query('startDate', OptionalDatePipe) startDate?: Date,
     @Query('endDate', OptionalDatePipe) endDate?: Date,
   ) {
-    return this.swapsService.calculateAffiliateFees(address, startDate, endDate)
+    return this.swapsService.calculateAffiliateFeesByPartnerCode(partnerCode, startDate, endDate)
   }
 }

--- a/apps/swap-service/src/swaps/swaps.service.ts
+++ b/apps/swap-service/src/swaps/swaps.service.ts
@@ -292,18 +292,13 @@ export class SwapsService {
     }
   }
 
-  async calculateAffiliateFees(address: string, startDate?: Date, endDate?: Date): Promise<Fees> {
+  async calculateAffiliateFeesByPartnerCode(partnerCode: string, startDate?: Date, endDate?: Date): Promise<Fees> {
     logger.log(
-      `Calculating affiliate fees for address: ${address}, period: ${startDate?.toISOString()} - ${endDate?.toISOString()}`,
+      `Calculating affiliate fees for ${partnerCode}, period: ${startDate?.toISOString()} - ${endDate?.toISOString()}`,
     )
 
     const fees = await this.aggregateFees({
-      baseWhere: {
-        affiliate: { OR: [{ walletAddress: address }, { receiveAddress: address }] },
-        isAffiliateVerified: true,
-        status: 'SUCCESS',
-        origin: 'api',
-      },
+      baseWhere: { partnerCode, isAffiliateVerified: true, status: 'SUCCESS', origin: 'api' },
       startDate,
       endDate,
       calcFee: (swap) => {
@@ -315,7 +310,7 @@ export class SwapsService {
     })
 
     logger.log(
-      `Affiliate fees for ${address}\n` +
+      `Affiliate fees for ${partnerCode}\n` +
         `  period:   ${fees.periodCount} swaps, $${fees.periodVolumeUsd.toFixed(2)} volume, $${fees.periodFeesUsd.toFixed(2)} fee\n` +
         `  all-time: ${fees.allTimeCount} swaps, $${fees.allTimeFeesUsd.toFixed(2)} fee`,
     )

--- a/apps/swap-service/src/swaps/swaps.service.ts
+++ b/apps/swap-service/src/swaps/swaps.service.ts
@@ -166,7 +166,8 @@ export class SwapsService {
           }
         }
       } catch (error) {
-        logger.warn(`Failed to resolve partner code ${data.partnerCode}:`, error)
+        logger.error(`Failed to resolve partner code ${data.partnerCode}:`, error)
+        throw error
       }
     }
 

--- a/apps/swap-service/src/swaps/swaps.service.ts
+++ b/apps/swap-service/src/swaps/swaps.service.ts
@@ -80,10 +80,10 @@ export class SwapsService {
     try {
       const affiliateFeeAssetId = resolveAffiliateFeeAssetId(data.swapperName, data.sellAsset, data.buyAsset)
 
-      const [referralCode, prices, partnerAddress] = await Promise.all([
+      const [referralCode, prices, partner] = await Promise.all([
         this.getReferralCode(data.userId),
         fetchUsdPrices(data, affiliateFeeAssetId),
-        this.resolvePartnerAddress(data),
+        this.resolvePartner(data),
       ])
 
       const sellAmountUsd = computeSellAmountUsd(
@@ -115,7 +115,8 @@ export class SwapsService {
             sellAssetUsd: prices.sellAssetUsd,
             buyAssetUsd: prices.buyAssetUsd,
             affiliateAssetUsd: prices.affiliateAssetUsd,
-            partnerAddress,
+            partnerAddress: partner.partnerAddress,
+            partnerCode: partner.partnerCode,
             partnerBps: data.partnerBps,
             affiliateBps: data.affiliateBps,
             shapeshiftBps: data.shapeshiftBps,
@@ -129,7 +130,7 @@ export class SwapsService {
         [
           `Swap created: ${swap.swapId}`,
           referralCode && `referral ${referralCode}`,
-          partnerAddress && `partner ${partnerAddress}`,
+          (partner.partnerCode ?? partner.partnerAddress) && `partner ${partner.partnerCode ?? partner.partnerAddress}`,
           sellAmountUsd && `$${sellAmountUsd}`,
         ]
           .filter(Boolean)
@@ -148,21 +149,28 @@ export class SwapsService {
     return this.userServiceClient.getUserReferralCode(userId)
   }
 
-  private async resolvePartnerAddress(data: CreateSwapDto): Promise<string | null> {
-    if (data.partnerAddress) return data.partnerAddress
-    if (!data.partnerCode) return null
+  private async resolvePartner(
+    data: CreateSwapDto,
+  ): Promise<{ partnerCode: string | null; partnerAddress: string | null }> {
+    if (data.partnerCode) {
+      try {
+        const affiliate = await this.prisma.affiliate.findUnique({
+          where: { partnerCode: data.partnerCode },
+          select: { partnerCode: true, receiveAddress: true, walletAddress: true },
+        })
 
-    try {
-      const affiliate = await this.prisma.affiliate.findFirst({
-        where: { partnerCode: data.partnerCode },
-        select: { receiveAddress: true, walletAddress: true },
-      })
-
-      return affiliate?.receiveAddress ?? affiliate?.walletAddress ?? null
-    } catch (error) {
-      logger.warn(`Failed to resolve partner address for partner code ${data.partnerCode}:`, error)
-      return null
+        if (affiliate) {
+          return {
+            partnerCode: affiliate.partnerCode,
+            partnerAddress: affiliate.receiveAddress ?? affiliate.walletAddress,
+          }
+        }
+      } catch (error) {
+        logger.warn(`Failed to resolve partner code ${data.partnerCode}:`, error)
+      }
     }
+
+    return { partnerCode: null, partnerAddress: data.partnerAddress ?? null }
   }
 
   async updateSwapStatus(data: UpdateSwapStatusDto): Promise<Swap> {
@@ -290,7 +298,12 @@ export class SwapsService {
     )
 
     const fees = await this.aggregateFees({
-      baseWhere: { partnerAddress: address, isAffiliateVerified: true, status: 'SUCCESS', origin: 'api' },
+      baseWhere: {
+        affiliate: { OR: [{ walletAddress: address }, { receiveAddress: address }] },
+        isAffiliateVerified: true,
+        status: 'SUCCESS',
+        origin: 'api',
+      },
       startDate,
       endDate,
       calcFee: (swap) => {

--- a/apps/swap-service/src/swaps/swaps.service.ts
+++ b/apps/swap-service/src/swaps/swaps.service.ts
@@ -171,7 +171,25 @@ export class SwapsService {
       }
     }
 
-    return { partnerCode: null, partnerAddress: data.partnerAddress ?? null }
+    if (data.partnerAddress) {
+      try {
+        const matches = await this.prisma.affiliate.findMany({
+          where: { OR: [{ walletAddress: data.partnerAddress }, { receiveAddress: data.partnerAddress }] },
+          select: { partnerCode: true },
+          take: 2,
+        })
+
+        return {
+          partnerCode: matches.length === 1 ? matches[0].partnerCode : null,
+          partnerAddress: data.partnerAddress,
+        }
+      } catch (error) {
+        logger.error(`Failed to resolve partner address ${data.partnerAddress}:`, error)
+        throw error
+      }
+    }
+
+    return { partnerCode: null, partnerAddress: null }
   }
 
   async updateSwapStatus(data: UpdateSwapStatusDto): Promise<Swap> {

--- a/apps/swap-service/src/verification/__tests__/fixtures/maya/swap.ts
+++ b/apps/swap-service/src/verification/__tests__/fixtures/maya/swap.ts
@@ -73,6 +73,7 @@ export default {
   isAffiliateVerified: null,
   affiliateVerificationDetails: null,
   partnerAddress: '0xA44C286BA83Bb771cd0107B2c1Df678435Bd1535',
+  partnerCode: 'testpartner',
   affiliateBps: 60,
   partnerBps: 50,
   origin: 'api',

--- a/apps/swap-service/src/verification/__tests__/fixtures/near/swap.ts
+++ b/apps/swap-service/src/verification/__tests__/fixtures/near/swap.ts
@@ -73,6 +73,7 @@ export default {
   affiliateVerificationDetails: null,
   verificationStatus: 'PENDING',
   partnerAddress: '0xa44c286ba83bb771cd0107b2c1df678435bd1535',
+  partnerCode: 'testpartner',
   affiliateBps: 60,
   partnerBps: 50,
   origin: 'api',

--- a/apps/swap-service/src/verification/__tests__/fixtures/relay/swap.ts
+++ b/apps/swap-service/src/verification/__tests__/fixtures/relay/swap.ts
@@ -82,6 +82,7 @@ export default {
     verifiedSellAmountCryptoBaseUnit: '1000000000000000',
   },
   partnerAddress: null,
+  partnerCode: null,
   affiliateBps: 60,
   partnerBps: 0,
   origin: 'api',

--- a/apps/swap-service/src/verification/__tests__/fixtures/thorchain/swap.ts
+++ b/apps/swap-service/src/verification/__tests__/fixtures/thorchain/swap.ts
@@ -73,6 +73,7 @@ export default {
   isAffiliateVerified: null,
   affiliateVerificationDetails: null,
   partnerAddress: '0xA44C286BA83Bb771cd0107B2c1Df678435Bd1535',
+  partnerCode: 'testpartner',
   affiliateBps: 60,
   partnerBps: 50,
   origin: 'api',

--- a/apps/swap-service/src/verification/swap-verification.service.ts
+++ b/apps/swap-service/src/verification/swap-verification.service.ts
@@ -644,7 +644,6 @@ export class SwapVerificationService {
     // TODO: Implement on-chain/API verification for AVNU
     const affiliateBps = swap.affiliateBps
     const hasAffiliate = affiliateBps > 0
-    const affiliateAddress = swap.partnerAddress ?? undefined
 
     const verifiedSellAmountCryptoBaseUnit = (
       (metadata?.sellAmountIncludingProtocolFeesCryptoBaseUnit as string | undefined) ?? swap.sellAmountCryptoBaseUnit
@@ -654,7 +653,6 @@ export class SwapVerificationService {
       verificationStatus: 'SUCCESS',
       hasAffiliate,
       affiliateBps: hasAffiliate ? affiliateBps : undefined,
-      affiliateAddress,
       verifiedSellAmountCryptoBaseUnit,
       actualBuyAmountCryptoBaseUnit: undefined,
       actualAffiliateFeeAmountCryptoBaseUnit: undefined,

--- a/prisma/migrations/20260626000000_swap_partner_code_attribution/migration.sql
+++ b/prisma/migrations/20260626000000_swap_partner_code_attribution/migration.sql
@@ -1,0 +1,45 @@
+-- Add stable partnerCode attribution alongside the existing partnerAddress snapshot.
+
+-- Add nullable partnerCode column to swaps
+ALTER TABLE "swaps" ADD COLUMN "partnerCode" CITEXT;
+
+-- Backfill partnerCode from the affiliate registry, matching the snapshotted
+-- partnerAddress against either the affiliate's receive or wallet address.
+-- Only attribute addresses that resolve to exactly one affiliate; ambiguous
+-- matches (shared receive address, etc.) are left NULL.
+UPDATE "swaps" s
+SET "partnerCode" = m.partner_code
+FROM (
+  SELECT addrs."partnerAddress" AS addr,
+         MIN(a."partner_code")   AS partner_code,
+         COUNT(*)                AS match_count
+  FROM (SELECT DISTINCT "partnerAddress" FROM "swaps" WHERE "partnerAddress" IS NOT NULL) addrs
+  JOIN "affiliates" a
+    ON a."partner_code" IS NOT NULL
+   AND (addrs."partnerAddress" = a."receive_address" OR addrs."partnerAddress" = a."wallet_address")
+  GROUP BY addrs."partnerAddress"
+) m
+WHERE s."partnerAddress" = m.addr
+  AND m.match_count = 1;
+
+-- Enforce that every affiliate has a partner code (now the canonical attribution key).
+-- Abort the migration if any legacy affiliate is missing one so they can be assigned first.
+DO $$
+BEGIN
+  IF EXISTS (SELECT 1 FROM "affiliates" WHERE "partner_code" IS NULL) THEN
+    RAISE EXCEPTION 'Cannot enforce NOT NULL: % affiliate row(s) have a NULL partner_code. Assign codes before migrating.',
+      (SELECT COUNT(*) FROM "affiliates" WHERE "partner_code" IS NULL);
+  END IF;
+END $$;
+
+ALTER TABLE "affiliates" ALTER COLUMN "partner_code" SET NOT NULL;
+
+-- Tie swaps to affiliates by partner code with referential integrity.
+ALTER TABLE "swaps"
+  ADD CONSTRAINT "swaps_partnerCode_fkey"
+  FOREIGN KEY ("partnerCode") REFERENCES "affiliates"("partner_code")
+  ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- Index the new attribution key. partnerAddress and its index are retained as a
+-- per-swap payout snapshot and for legacy callers still attributing by address.
+CREATE INDEX "swaps_partnerCode_idx" ON "swaps"("partnerCode");

--- a/prisma/schema/swap-service.prisma
+++ b/prisma/schema/swap-service.prisma
@@ -2,11 +2,12 @@ model Affiliate {
   id             String   @id @default(cuid())
   walletAddress  String   @unique @map("wallet_address") @db.Citext
   receiveAddress String?  @map("receive_address") @db.Citext
-  partnerCode    String?  @unique @map("partner_code") @db.Citext
+  partnerCode    String   @unique @map("partner_code") @db.Citext
   bps            Int      @default(60)
   isActive       Boolean  @default(true) @map("is_active")
   createdAt      DateTime @default(now()) @map("created_at")
   updatedAt      DateTime @updatedAt @map("updated_at")
+  swaps          Swap[]
 
   @@index([partnerCode])
   @@index([isActive])
@@ -42,6 +43,8 @@ model Swap {
   isAffiliateVerified                    Boolean?
   affiliateVerificationDetails           Json?
   partnerAddress                         String?            @db.Citext
+  partnerCode                            String?            @db.Citext
+  affiliate                              Affiliate?         @relation(fields: [partnerCode], references: [partnerCode])
   partnerBps                             Int                @default(0)
   affiliateBps                           Int
   shapeshiftBps                          Int
@@ -52,6 +55,7 @@ model Swap {
 
   @@index([referralCode])
   @@index([partnerAddress])
+  @@index([partnerCode])
   @@index([status, sellTxHash])
   @@index([verificationStatus, status])
   @@index([userId])


### PR DESCRIPTION
## Description

Swaps now attribute to partners by a **stable `partnerCode`** (a real FK to the affiliate registry) instead of the mutable `partnerAddress` payout snapshot. This fixes two latent bugs in the old address-keyed attribution:

- **Address changes fragment history** — if a partner updates their `receiveAddress`, their swaps split across the old and new address, and no single address returns all of them.
- **Shared `receiveAddress` mixes partners** — `receiveAddress` isn't unique, so address filtering could return two partners' swaps together.

`partnerCode` is unique, stable, and FK-enforced, so a partner sees all their swaps regardless of address history.

### What changed
- **Schema**: `Swap.partnerCode` added as a real relation to `Affiliate.partnerCode` (now `NOT NULL`); `@@index([partnerCode])`. `partnerAddress` is **kept** as a per-swap payout snapshot (for the legacy migration window and to leave the settlement payout policy — per-swap vs. current — open).
- **Migration** (`20260626000000_swap_partner_code_attribution`): backfill `partnerCode` from `partnerAddress` (unambiguous registry matches only) → guard-abort if any affiliate lacks a code → `SET NOT NULL` → add FK (`ON DELETE SET NULL / ON UPDATE CASCADE`) → add index. Additive; `partnerAddress` untouched.
- **Write path**: `resolvePartner` stamps a registry-resolved `partnerCode` plus the affiliate's current payout address as a snapshot; unknown/absent codes fall back to a raw `partnerAddress` with null code (FK-safe).
- **Reads**: attribution filters through the `affiliate` relation / `partnerCode`, never `partnerAddress`. New code-keyed `getAffiliate{Stats,Swaps}ByPartnerCode` for settlement/reporting.
- **`GET /v1/affiliate/{swaps,stats}`**: dual-param — accept `partnerCode` (preferred) or `address` during the migration window; 400 if neither.
- **`GET /swaps/affiliate-fees/:partnerCode`**: migrated straight to `partnerCode` (the endpoint has no callers anywhere in the org, so no bridge needed).
- Removed the dead `partnerAddress` passthrough in the AVNU verifier stub (never used on-chain).

### Migration safety
The full migration was executed transactionally (and rolled back) against **both prod and develop** DBs — runs cleanly, FK creates against the `affiliates_partner_code_key` unique index, NOT-NULL guard doesn't fire (0 null-code affiliates in either env). Backfill attributes 9 swaps on prod / 38 on develop; junk/unmatched addresses safely land as null `partnerCode`. Nothing manual required beyond `yarn db:migrate`.

### Follow-ups (not in this PR)
- **API migration phases 2/3**: move public-api to forward `partnerCode` (it currently sends `address` to `/v1/affiliate/{stats,swaps}`), then contract out `address`.
- **Partner payout / settlement script** (the eventual consumer of this data): needs a settlement ledger for idempotency, per-asset payable amounts (`actualAffiliateFeeAmountCryptoBaseUnit × partner rate`), and the per-swap-vs-current payout-address decision. `/swaps/affiliate-fees` is a USD reporting view, not the payout engine.
- **Poller gap** (separate finding): `checkSwapStatus` never inspects the source-tx receipt, so reverted/fabricated-hash swaps sit PENDING forever — should fail on `receipt.status === 0` / never-mined.

## Testing
- `yarn jest` in `apps/swap-service` — **58/58 pass** (added attribution-read guards: by-address filters via the relation, by-code filters directly, neither touches `partnerAddress`).
- `eslint` clean on all changed files.
- `prisma validate` passes; full migration dry-run verified transactionally against prod and develop (see Migration safety above).