### PR TITLE
feat(swap-service): affiliate stats/swaps reads are partnerCode-only

### DIFF
--- a/apps/swap-service/src/affiliate/__tests__/affiliate.service.test.ts
+++ b/apps/swap-service/src/affiliate/__tests__/affiliate.service.test.ts
@@ -90,40 +90,12 @@ describe('AffiliateService.createAffiliate', () => {
 })
 
 describe('AffiliateService attribution reads', () => {
-  const address = '0x1111111111111111111111111111111111111111'
-
   // Pull the `where` from the first prisma.swap.findMany call as a typed object so the
   // assertions below don't trip the no-unsafe-any lint rules on jest's `any`-typed calls.
   const whereOfFirstCall = (findMany: jest.Mock): Record<string, unknown> => {
     const [[args]] = findMany.mock.calls as Array<[{ where: Record<string, unknown> }]>
     return args.where
   }
-
-  it('getAffiliateStatsByAddress filters through the affiliate relation, never partnerAddress', async () => {
-    const findMany = jest.fn().mockResolvedValue([])
-    const service = new AffiliateService(makePrismaMock(undefined, findMany))
-
-    await service.getAffiliateStatsByAddress(address, {})
-
-    const where = whereOfFirstCall(findMany)
-    expect(where).toMatchObject({
-      affiliate: { OR: [{ walletAddress: address }, { receiveAddress: address }] },
-    })
-    expect(where).not.toHaveProperty('partnerAddress')
-  })
-
-  it('getAffiliateSwapsByAddress filters through the affiliate relation, never partnerAddress', async () => {
-    const findMany = jest.fn().mockResolvedValue([])
-    const service = new AffiliateService(makePrismaMock(undefined, findMany))
-
-    await service.getAffiliateSwapsByAddress(address, { limit: 50 })
-
-    const where = whereOfFirstCall(findMany)
-    expect(where).toMatchObject({
-      affiliate: { OR: [{ walletAddress: address }, { receiveAddress: address }] },
-    })
-    expect(where).not.toHaveProperty('partnerAddress')
-  })
 
   it('getAffiliateSwapsByPartnerCode filters directly on partnerCode, with no join or address', async () => {
     const findMany = jest.fn().mockResolvedValue([])

--- a/apps/swap-service/src/affiliate/__tests__/affiliate.service.test.ts
+++ b/apps/swap-service/src/affiliate/__tests__/affiliate.service.test.ts
@@ -97,11 +97,11 @@ describe('AffiliateService attribution reads', () => {
     return args.where
   }
 
-  it('getAffiliateSwapsByPartnerCode filters directly on partnerCode, with no join or address', async () => {
+  it('getAffiliateSwaps filters directly on partnerCode, with no join or address', async () => {
     const findMany = jest.fn().mockResolvedValue([])
     const service = new AffiliateService(makePrismaMock(undefined, findMany))
 
-    await service.getAffiliateSwapsByPartnerCode('goodcode', { limit: 50 })
+    await service.getAffiliateSwaps('goodcode', { limit: 50 })
 
     const where = whereOfFirstCall(findMany)
     expect(where).toMatchObject({ partnerCode: 'goodcode' })
@@ -109,11 +109,11 @@ describe('AffiliateService attribution reads', () => {
     expect(where).not.toHaveProperty('partnerAddress')
   })
 
-  it('getAffiliateStatsByPartnerCode filters directly on partnerCode, with no join or address', async () => {
+  it('getAffiliateStats filters directly on partnerCode, with no join or address', async () => {
     const findMany = jest.fn().mockResolvedValue([])
     const service = new AffiliateService(makePrismaMock(undefined, findMany))
 
-    const result = await service.getAffiliateStatsByPartnerCode('goodcode', {})
+    const result = await service.getAffiliateStats('goodcode', {})
 
     const where = whereOfFirstCall(findMany)
     expect(where).toMatchObject({ partnerCode: 'goodcode', status: 'SUCCESS', isAffiliateVerified: true })

--- a/apps/swap-service/src/affiliate/affiliate.controller.ts
+++ b/apps/swap-service/src/affiliate/affiliate.controller.ts
@@ -32,16 +32,12 @@ export class AffiliateController {
 
   @Get('swaps')
   async getSwaps(@Query() query: AffiliateSwapsQueryDto) {
-    if (query.partnerCode) return this.affiliateService.getAffiliateSwapsByPartnerCode(query.partnerCode, query)
-    if (query.address) return this.affiliateService.getAffiliateSwapsByAddress(query.address, query)
-    throw new BadRequestException('partnerCode or address is required')
+    return this.affiliateService.getAffiliateSwapsByPartnerCode(query.partnerCode, query)
   }
 
   @Get('stats')
   async getStats(@Query() query: AffiliateStatsQueryDto) {
-    if (query.partnerCode) return this.affiliateService.getAffiliateStatsByPartnerCode(query.partnerCode, query)
-    if (query.address) return this.affiliateService.getAffiliateStatsByAddress(query.address, query)
-    throw new BadRequestException('partnerCode or address is required')
+    return this.affiliateService.getAffiliateStatsByPartnerCode(query.partnerCode, query)
   }
 
   @Get(':address')

--- a/apps/swap-service/src/affiliate/affiliate.controller.ts
+++ b/apps/swap-service/src/affiliate/affiliate.controller.ts
@@ -32,12 +32,12 @@ export class AffiliateController {
 
   @Get('swaps')
   async getSwaps(@Query() query: AffiliateSwapsQueryDto) {
-    return this.affiliateService.getAffiliateSwapsByPartnerCode(query.partnerCode, query)
+    return this.affiliateService.getAffiliateSwaps(query.partnerCode, query)
   }
 
   @Get('stats')
   async getStats(@Query() query: AffiliateStatsQueryDto) {
-    return this.affiliateService.getAffiliateStatsByPartnerCode(query.partnerCode, query)
+    return this.affiliateService.getAffiliateStats(query.partnerCode, query)
   }
 
   @Get(':address')

--- a/apps/swap-service/src/affiliate/affiliate.service.ts
+++ b/apps/swap-service/src/affiliate/affiliate.service.ts
@@ -7,13 +7,7 @@ import { PaginatedSwaps } from '../swaps/types'
 import { calculateFeeForSwap, getPartnerFeeRate, toSwap } from '../swaps/utils'
 import { getNextCursor, swapCursorArgs } from '../utils/pagination'
 
-import type {
-  AffiliateStatsQueryDto,
-  AffiliateStatsResult,
-  AffiliateSwapsQueryDto,
-  CreateAffiliateDto,
-  UpdateAffiliateDto,
-} from './types'
+import type { AffiliateStatsResult, CreateAffiliateDto, UpdateAffiliateDto } from './types'
 import { isReservedPartnerCode } from './utils'
 
 @Injectable()
@@ -64,49 +58,6 @@ export class AffiliateService {
     return this.prisma.affiliate.update({ where: { walletAddress }, data: updateData })
   }
 
-  async getAffiliateStatsByAddress(address: string, options: AffiliateStatsQueryDto): Promise<AffiliateStatsResult> {
-    const { startDate, endDate } = options
-
-    const items = await this.prisma.swap.findMany({
-      where: {
-        affiliate: { OR: [{ walletAddress: address }, { receiveAddress: address }] },
-        status: 'SUCCESS',
-        isAffiliateVerified: true,
-        ...(startDate || endDate
-          ? {
-              createdAt: {
-                ...(startDate && { gte: startDate }),
-                ...(endDate && { lte: endDate }),
-              },
-            }
-          : {}),
-      },
-    })
-
-    let totalSwaps = 0
-    let totalVolumeUsd = 0
-    let totalFeesEarnedUsd = 0
-
-    for (const item of items) {
-      const swap = toSwap(item)
-
-      const fee = calculateFeeForSwap(swap)
-      if (!fee) continue
-
-      const rate = getPartnerFeeRate(fee.verifiedBps, swap.partnerBps)
-
-      totalSwaps++
-      totalVolumeUsd += fee.volumeUsd
-      totalFeesEarnedUsd += fee.feeUsd * rate
-    }
-
-    return {
-      totalSwaps,
-      totalVolumeUsd: totalVolumeUsd.toFixed(2),
-      totalFeesEarnedUsd: totalFeesEarnedUsd.toFixed(2),
-    }
-  }
-
   async getAffiliateStatsByPartnerCode(
     partnerCode: string,
     options: { startDate?: Date; endDate?: Date },
@@ -150,30 +101,6 @@ export class AffiliateService {
       totalSwaps,
       totalVolumeUsd: totalVolumeUsd.toFixed(2),
       totalFeesEarnedUsd: totalFeesEarnedUsd.toFixed(2),
-    }
-  }
-
-  async getAffiliateSwapsByAddress(address: string, options: AffiliateSwapsQueryDto): Promise<PaginatedSwaps> {
-    const { startDate, endDate, limit, cursor } = options
-
-    const items = await this.prisma.swap.findMany({
-      ...swapCursorArgs(limit, cursor),
-      where: {
-        affiliate: { OR: [{ walletAddress: address }, { receiveAddress: address }] },
-        ...(startDate || endDate
-          ? {
-              createdAt: {
-                ...(startDate && { gte: startDate }),
-                ...(endDate && { lte: endDate }),
-              },
-            }
-          : {}),
-      },
-    })
-
-    return {
-      swaps: items.map(toSwap),
-      nextCursor: getNextCursor(items, limit),
     }
   }
 

--- a/apps/swap-service/src/affiliate/affiliate.service.ts
+++ b/apps/swap-service/src/affiliate/affiliate.service.ts
@@ -58,7 +58,7 @@ export class AffiliateService {
     return this.prisma.affiliate.update({ where: { walletAddress }, data: updateData })
   }
 
-  async getAffiliateStatsByPartnerCode(
+  async getAffiliateStats(
     partnerCode: string,
     options: { startDate?: Date; endDate?: Date },
   ): Promise<AffiliateStatsResult> {
@@ -104,7 +104,7 @@ export class AffiliateService {
     }
   }
 
-  async getAffiliateSwapsByPartnerCode(
+  async getAffiliateSwaps(
     partnerCode: string,
     options: { startDate?: Date; endDate?: Date; limit: number; cursor?: string },
   ): Promise<PaginatedSwaps> {

--- a/apps/swap-service/src/affiliate/types.ts
+++ b/apps/swap-service/src/affiliate/types.ts
@@ -14,13 +14,8 @@ export interface AffiliateStatsResult {
 }
 
 export class AffiliateStatsQueryDto {
-  @IsOptional()
-  @IsEthereumAddress()
-  address?: string
-
-  @IsOptional()
   @Matches(PARTNER_CODE_REGEX, { message: PARTNER_CODE_MESSAGE })
-  partnerCode?: string
+  partnerCode: string
 
   @IsOptional()
   @Type(() => Date)
@@ -34,13 +29,8 @@ export class AffiliateStatsQueryDto {
 }
 
 export class AffiliateSwapsQueryDto extends PaginationQueryDto {
-  @IsOptional()
-  @IsEthereumAddress()
-  address?: string
-
-  @IsOptional()
   @Matches(PARTNER_CODE_REGEX, { message: PARTNER_CODE_MESSAGE })
-  partnerCode?: string
+  partnerCode: string
 
   @IsOptional()
   @Type(() => Date)

--- a/apps/swap-service/src/swaps/swaps.controller.ts
+++ b/apps/swap-service/src/swaps/swaps.controller.ts
@@ -48,6 +48,6 @@ export class SwapsController {
     @Query('startDate', OptionalDatePipe) startDate?: Date,
     @Query('endDate', OptionalDatePipe) endDate?: Date,
   ) {
-    return this.swapsService.calculateAffiliateFeesByPartnerCode(partnerCode, startDate, endDate)
+    return this.swapsService.calculateAffiliateFees(partnerCode, startDate, endDate)
   }
 }

--- a/apps/swap-service/src/swaps/swaps.service.ts
+++ b/apps/swap-service/src/swaps/swaps.service.ts
@@ -311,7 +311,7 @@ export class SwapsService {
     }
   }
 
-  async calculateAffiliateFeesByPartnerCode(partnerCode: string, startDate?: Date, endDate?: Date): Promise<Fees> {
+  async calculateAffiliateFees(partnerCode: string, startDate?: Date, endDate?: Date): Promise<Fees> {
     logger.log(
       `Calculating affiliate fees for ${partnerCode}, period: ${startDate?.toISOString()} - ${endDate?.toISOString()}`,
     )


### PR DESCRIPTION
## Description

Contract step after #44. Now that public-api queries `/v1/affiliate/{stats,swaps}` by `partnerCode` (shapeshift/web#12473), drop the legacy `address` path from those reads — `partnerCode` is the sole, canonical attribution key.

- DTOs (`AffiliateStatsQueryDto`, `AffiliateSwapsQueryDto`): `partnerCode` is now required; the optional `address` field is removed.
- Controller: `/swaps` and `/stats` route straight to the partnerCode methods (no `address` branch, no "one of" 400).
- Service: removed the now-dead `getAffiliateStatsByAddress` / `getAffiliateSwapsByAddress` and their tests.

`partnerAddress` is untouched on the **write** side — it remains the per-swap payout snapshot and feeds the `resolvePartner` reverse-lookup for `X-Partner-Address` callers. This PR only removes the address-based **read** path.

### Deploy ordering
Ship after web#12473 (which makes public-api send `partnerCode` on reads). Until then, the only caller is public-api; once it's on `partnerCode`, the `address` read path here is dead. swap-service is API-key gated, so there are no other callers.

## Testing
- `yarn jest` (swap-service): 56/56 pass (removed the 2 obsolete by-address read tests).
- `eslint` clean on changed files.