### PR TITLE
fix(affiliate): exact partner-fee math via getPartnerFeeUsd across stats, swaps, and payouts

### DIFF
--- a/apps/swap-service/src/affiliate/affiliate.service.ts
+++ b/apps/swap-service/src/affiliate/affiliate.service.ts
@@ -1,9 +1,10 @@
 import { Injectable, NotFoundException } from '@nestjs/common'
 import { Affiliate, Prisma } from '@prisma/client'
+import { bnOrZero } from '@shapeshiftoss/chain-adapters'
 
 import { PrismaService } from '../prisma/prisma.service'
 import { SHAPESHIFT_BPS } from '../swaps/constants'
-import { calculateFeeForSwap, getPartnerFeeRate, getPartnerFeeUsd, toSwap } from '../swaps/utils'
+import { calculateFeeForSwap, getPartnerFeeUsd, toSwap } from '../swaps/utils'
 import { getNextCursor, swapCursorArgs } from '../utils/pagination'
 
 import type { AffiliateStatsResult, CreateAffiliateDto, UpdateAffiliateDto } from './types'
@@ -84,8 +85,8 @@ export class AffiliateService {
     })
 
     let totalSwaps = 0
-    let totalVolumeUsd = 0
-    let totalFeesEarnedUsd = 0
+    let totalVolumeUsd = bnOrZero(0)
+    let totalFeesEarnedUsd = bnOrZero(0)
 
     for (const item of items) {
       const swap = toSwap(item)
@@ -93,11 +94,9 @@ export class AffiliateService {
       const fee = calculateFeeForSwap(swap)
       if (!fee) continue
 
-      const rate = getPartnerFeeRate(fee.verifiedBps, swap.partnerBps)
-
       totalSwaps++
-      totalVolumeUsd += fee.volumeUsd
-      totalFeesEarnedUsd += fee.feeUsd * rate
+      totalVolumeUsd = totalVolumeUsd.plus(fee.volumeUsd)
+      totalFeesEarnedUsd = totalFeesEarnedUsd.plus(getPartnerFeeUsd(fee.feeUsd, fee.verifiedBps, swap.partnerBps))
     }
 
     return {

--- a/apps/swap-service/src/affiliate/affiliate.service.ts
+++ b/apps/swap-service/src/affiliate/affiliate.service.ts
@@ -3,7 +3,7 @@ import { Affiliate, Prisma } from '@prisma/client'
 
 import { PrismaService } from '../prisma/prisma.service'
 import { SHAPESHIFT_BPS } from '../swaps/constants'
-import { calculateFeeForSwap, getPartnerFeeRate, toSwap } from '../swaps/utils'
+import { calculateFeeForSwap, getPartnerFeeRate, getPartnerFeeUsd, toSwap } from '../swaps/utils'
 import { getNextCursor, swapCursorArgs } from '../utils/pagination'
 
 import type { AffiliateStatsResult, CreateAffiliateDto, UpdateAffiliateDto } from './types'
@@ -133,7 +133,7 @@ export class AffiliateService {
       const fee = calculateFeeForSwap(swap)
       const feeUsd = fee ? fee.feeUsd.toString() : null
       const volumeUsd = fee ? fee.volumeUsd.toString() : null
-      const partnerFeeUsd = fee ? (fee.feeUsd * getPartnerFeeRate(fee.verifiedBps, swap.partnerBps)).toString() : null
+      const partnerFeeUsd = fee ? getPartnerFeeUsd(fee.feeUsd, fee.verifiedBps, swap.partnerBps) : null
       return { ...swap, feeUsd, partnerFeeUsd, volumeUsd }
     })
 

--- a/apps/swap-service/src/affiliate/affiliate.service.ts
+++ b/apps/swap-service/src/affiliate/affiliate.service.ts
@@ -1,5 +1,6 @@
 import { Injectable, NotFoundException } from '@nestjs/common'
 import { Affiliate, Prisma } from '@prisma/client'
+
 import { bnOrZero } from '@shapeshiftoss/chain-adapters'
 
 import { PrismaService } from '../prisma/prisma.service'

--- a/apps/swap-service/src/swaps/utils.ts
+++ b/apps/swap-service/src/swaps/utils.ts
@@ -61,6 +61,15 @@ export const getPartnerFeeRate = (verifiedBps: number, partnerBps: number): numb
   return Math.min(partnerBps / verifiedBps, 1)
 }
 
+// The partner's share of the affiliate fee in USD, as an exact string. Multiplies before dividing
+// (feeUsd × partnerBps ÷ verifiedBps) so the result stays precise — unlike feeUsd × getPartnerFeeRate,
+// where the intermediate rate (e.g. 50/60) is a lossy float. Capped at the whole fee, matching the rate cap.
+export const getPartnerFeeUsd = (feeUsd: number, verifiedBps: number, partnerBps: number): string => {
+  if (verifiedBps <= 0) return '0'
+  const share = bnOrZero(feeUsd).times(partnerBps).div(verifiedBps)
+  return (share.gt(feeUsd) ? bnOrZero(feeUsd) : share).toString()
+}
+
 export const computeSellAmountUsd = (
   sellAmountCryptoBaseUnit: string,
   precision: number,

--- a/apps/swap-service/src/swaps/utils.ts
+++ b/apps/swap-service/src/swaps/utils.ts
@@ -56,14 +56,9 @@ export const formatAmount = (amount: string | number): string => {
     .replace(/\.?0+$/, '')
 }
 
-export const getPartnerFeeRate = (verifiedBps: number, partnerBps: number): number => {
-  if (verifiedBps <= 0) return 0
-  return Math.min(partnerBps / verifiedBps, 1)
-}
-
 // The partner's share of the affiliate fee in USD, as an exact string. Multiplies before dividing
-// (feeUsd × partnerBps ÷ verifiedBps) so the result stays precise — unlike feeUsd × getPartnerFeeRate,
-// where the intermediate rate (e.g. 50/60) is a lossy float. Capped at the whole fee, matching the rate cap.
+// (feeUsd × partnerBps ÷ verifiedBps) so the result stays precise — computing a partnerBps/verifiedBps
+// rate first (e.g. 50/60) would introduce lossy-float artifacts. Capped at the whole fee.
 export const getPartnerFeeUsd = (feeUsd: number, verifiedBps: number, partnerBps: number): string => {
   if (verifiedBps <= 0) return '0'
   const share = bnOrZero(feeUsd).times(partnerBps).div(verifiedBps)

--- a/scripts/affiliate-payouts/affiliate-payouts.test.ts
+++ b/scripts/affiliate-payouts/affiliate-payouts.test.ts
@@ -36,7 +36,8 @@ const stubDeps: FeeDeps<PrismaSwap> = {
     if (r.priceable === false) return null
     return { feeUsd: 12, volumeUsd: 2000, verifiedBps: 60, actualFeeUsd: 12, impliedFeeUsd: 12, ...r.fee }
   },
-  getPartnerFeeRate: (verifiedBps, partnerBps) => (verifiedBps <= 0 ? 0 : Math.min(partnerBps / verifiedBps, 1)),
+  getPartnerFeeUsd: (feeUsd, verifiedBps, partnerBps) =>
+    verifiedBps <= 0 ? '0' : BigNumber.min(new BigNumber(feeUsd).times(partnerBps).div(verifiedBps), feeUsd).toString(),
 }
 
 const accrual = (over: Partial<PartnerAccrual> & Pick<PartnerAccrual, 'partnerCode'>): PartnerAccrual => ({

--- a/scripts/affiliate-payouts/affiliate-payouts.ts
+++ b/scripts/affiliate-payouts/affiliate-payouts.ts
@@ -2,7 +2,7 @@ import { PrismaClient } from '@prisma/client'
 import * as fs from 'fs'
 import * as path from 'path'
 
-import { calculateFeeForSwap, getPartnerFeeRate, toSwap } from '../../apps/swap-service/src/swaps/utils'
+import { calculateFeeForSwap, getPartnerFeeUsd, toSwap } from '../../apps/swap-service/src/swaps/utils'
 
 import type { PartnerPayout, PayoutRecord } from './types'
 import { aggregateByPartner, buildPayouts, buildRecord, resolveWindow, toCsv } from './utils'
@@ -88,7 +88,7 @@ async function generate(monthArg: string | undefined, force: boolean): Promise<v
   console.log(`Found ${rows.length} successful swaps with a partner code`)
 
   const { partners, unpriceableSwaps, anomalies, unverified, noAffiliateFee, partnerBpsUnset, unresolvedFee } =
-    aggregateByPartner(rows, { toSwap, calculateFeeForSwap, getPartnerFeeRate })
+    aggregateByPartner(rows, { toSwap, calculateFeeForSwap, getPartnerFeeUsd })
 
   const affiliates = await prisma.affiliate.findMany({
     where: { partnerCode: { in: Array.from(partners.keys()) } },

--- a/scripts/affiliate-payouts/types.ts
+++ b/scripts/affiliate-payouts/types.ts
@@ -74,7 +74,7 @@ export type AggregateResult = {
 export type FeeDeps<S> = {
   toSwap: (row: PrismaSwap) => S
   calculateFeeForSwap: (swap: S) => FeeResult | null
-  getPartnerFeeRate: (verifiedBps: number, partnerBps: number) => number
+  getPartnerFeeUsd: (feeUsd: number, verifiedBps: number, partnerBps: number) => string
 }
 
 export type PayoutWarning = {

--- a/scripts/affiliate-payouts/utils.ts
+++ b/scripts/affiliate-payouts/utils.ts
@@ -141,8 +141,7 @@ export function aggregateByPartner<S>(
       continue
     }
 
-    const rate = deps.getPartnerFeeRate(fee.verifiedBps, row.partnerBps)
-    if (rate <= 0) {
+    if (row.partnerBps <= 0) {
       partnerBpsUnset.push({
         swapId: row.swapId,
         partnerCode,
@@ -159,9 +158,10 @@ export function aggregateByPartner<S>(
       feesEarnedUsd: new BigNumber(0),
     }
 
+    // Pay only on the verified on-chain fee, via the shared exact partner-share helper.
     accrual.swapCount += 1
     accrual.volumeUsd = accrual.volumeUsd.plus(fee.volumeUsd)
-    accrual.feesEarnedUsd = accrual.feesEarnedUsd.plus(new BigNumber(fee.actualFeeUsd).times(rate))
+    accrual.feesEarnedUsd = accrual.feesEarnedUsd.plus(deps.getPartnerFeeUsd(fee.actualFeeUsd, fee.verifiedBps, row.partnerBps))
 
     partners.set(partnerCode.toLowerCase(), accrual)
   }


### PR DESCRIPTION
## Description

Consolidates the partner-fee-share calculation onto a single exact helper, `getPartnerFeeUsd`, and removes `getPartnerFeeRate`.

The old pattern `feeUsd × getPartnerFeeRate(...)` multiplies by a **lossy float rate** (e.g. `50/60 → 0.8333…4`), which reintroduces binary-float artifacts (e.g. `"0.050000000000000004"`). `getPartnerFeeUsd` multiplies **before** dividing (`feeUsd × partnerBps ÷ verifiedBps`, capped at the fee), so the result is exact.

Applied across all three consumers:
- **`getAffiliateSwaps`** — per-swap `partnerFeeUsd` (a full-precision string, so the artifact was directly visible in the response)
- **`getAffiliateStats`** — aggregate totals accumulated in BigNumber, so they reconcile exactly with the sum of the per-swap rows
- **affiliate-payouts script** (`aggregateByPartner`) — pays the partner share via the same helper; the `partnerBpsUnset` bucket now gates on `partnerBps` directly. **Payout amounts are unchanged** (they floor to 6 dp), so there it's precision-hygiene, not a value change.

With all three on `getPartnerFeeUsd`, `getPartnerFeeRate` has no remaining callers and is deleted.

Follow-up to #50 (partner revenue breakout) — the get-stats/get-swaps precision changes were split out of that PR so the fee-precision work reviews as one holistic unit.

## Testing

- `yarn build` — all 6 packages build
- swap-service — affiliate tests pass (8/8)
- `yarn affiliate-payouts:test` — 25/25 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)