### PR TITLE
fix(swaps): skip fee calc quietly for unverified swaps

### DIFF
--- a/apps/swap-service/src/swaps/__tests__/utils.test.ts
+++ b/apps/swap-service/src/swaps/__tests__/utils.test.ts
@@ -10,6 +10,7 @@ import { calculateFeeForSwap } from '../utils'
 const makeSwap = (overrides: Partial<Swap> = {}): Swap =>
   ({
     swapId: 'test-swap',
+    isAffiliateVerified: true,
     sellAsset: { assetId: 'eip155:1/slip44:60', precision: 18 },
     buyAsset: { assetId: 'eip155:1/erc20:0xusdc', precision: 6 },
     sellAssetUsd: '2000',
@@ -29,6 +30,14 @@ const makeSwap = (overrides: Partial<Swap> = {}): Swap =>
 
 describe('calculateFeeForSwap volume reconstruction', () => {
   afterEach(() => jest.restoreAllMocks())
+
+  it('returns null without warning for a swap that is not affiliate-verified', () => {
+    const warn = jest.spyOn(Logger.prototype, 'warn').mockImplementation(() => undefined)
+
+    // e.g. a failed / unverified swap surfaced by the partner swaps listing
+    expect(calculateFeeForSwap(makeSwap({ isAffiliateVerified: false, affiliateVerificationDetails: null }))).toBeNull()
+    expect(warn).not.toHaveBeenCalled()
+  })
 
   it('uses the sell-side USD as volume for a 0-bps swap when the sell price is present', () => {
     const result = calculateFeeForSwap(makeSwap())

--- a/apps/swap-service/src/swaps/swaps.service.ts
+++ b/apps/swap-service/src/swaps/swaps.service.ts
@@ -399,8 +399,11 @@ export class SwapsService {
       return toSwap(
         await this.prisma.swap.update({
           where: { swapId: swap.swapId },
-          // Clear any stale details so isAffiliateVerified=false always implies null details.
-        data: { verificationStatus: 'FAILED', isAffiliateVerified: false, affiliateVerificationDetails: Prisma.DbNull },
+          data: {
+            verificationStatus: 'FAILED',
+            isAffiliateVerified: false,
+            affiliateVerificationDetails: Prisma.DbNull,
+          },
         }),
       )
     }

--- a/apps/swap-service/src/swaps/swaps.service.ts
+++ b/apps/swap-service/src/swaps/swaps.service.ts
@@ -399,7 +399,8 @@ export class SwapsService {
       return toSwap(
         await this.prisma.swap.update({
           where: { swapId: swap.swapId },
-          data: { verificationStatus: 'FAILED', isAffiliateVerified: false },
+          // Clear any stale details so isAffiliateVerified=false always implies null details.
+        data: { verificationStatus: 'FAILED', isAffiliateVerified: false, affiliateVerificationDetails: Prisma.DbNull },
         }),
       )
     }

--- a/apps/swap-service/src/swaps/utils.ts
+++ b/apps/swap-service/src/swaps/utils.ts
@@ -168,9 +168,6 @@ export const calculateFeeForSwap = (
   actualFeeUsd: number | null
   impliedFeeUsd: number | null
 } | null => {
-  // Only affiliate-verified swaps can carry a fee. Failed / pending / no-affiliate swaps
-  // legitimately have none, and callers like the swaps listing pass them through — return
-  // quietly without warning. Past this point a missing field is genuinely unexpected.
   if (!swap.isAffiliateVerified) return null
 
   const verifiedBps = swap.affiliateVerificationDetails?.affiliateBps

--- a/apps/swap-service/src/swaps/utils.ts
+++ b/apps/swap-service/src/swaps/utils.ts
@@ -168,6 +168,11 @@ export const calculateFeeForSwap = (
   actualFeeUsd: number | null
   impliedFeeUsd: number | null
 } | null => {
+  // Only affiliate-verified swaps can carry a fee. Failed / pending / no-affiliate swaps
+  // legitimately have none, and callers like the swaps listing pass them through — return
+  // quietly without warning. Past this point a missing field is genuinely unexpected.
+  if (!swap.isAffiliateVerified) return null
+
   const verifiedBps = swap.affiliateVerificationDetails?.affiliateBps
   if (verifiedBps === undefined) {
     logger.warn(`Verified swap ${swap.swapId} missing affiliate bps in verification details, skipping`)


### PR DESCRIPTION
## Description

The partner swaps listing (`getAffiliateSwaps`) queries by `partnerCode` only — no `isAffiliateVerified`/`status` filter — so it intentionally includes failed/unverified swaps to display them, then runs each through `calculateFeeForSwap`. For a failed/unverified row (no `affiliateVerificationDetails`), that logged a misleading `WARN [SwapsService] Verified swap <id> missing affiliate bps in verification details, skipping` on every fetch, even though the row correctly resolves to null fees.

`verifySwap` only sets `isAffiliateVerified = true` for a successful affiliate swap (failed/pending/no-affiliate → false), so it's the clean gate. Add an early `return null` on `!isAffiliateVerified` in `calculateFeeForSwap`: those legitimately have no fee, so skip silently. The WARN now fires only for the genuinely unexpected case — a *verified* swap missing bps/sell amount.

Centralized in `calculateFeeForSwap` so all callers benefit (`getAffiliateSwaps`, `getPartnerStats`, `calculateReferralFees`); the stats paths already filter `isAffiliateVerified: true` so their behavior is unchanged.

## Testing

- `yarn test swaps/__tests__/utils.test.ts` — 4/4 pass, including a new case asserting an unverified swap returns `null` **without** logging a warning (spies on `Logger.prototype.warn`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fee calculation now safely returns no fee for swaps that are not affiliate-verified.
  * Reduced unnecessary warning messages for swaps that should be skipped quietly.
  * Updated test coverage to reflect the new behavior and default swap setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->