### PR TITLE
fix(swap-verification): stop inflating MAYAChain CACAO amounts 100x

### DIFF
--- a/apps/swap-service/src/verification/__tests__/mayachain.test.ts
+++ b/apps/swap-service/src/verification/__tests__/mayachain.test.ts
@@ -38,6 +38,39 @@ describe('verifyMayachain', () => {
     })
   })
 
+  // Midgard normalizes every coin to 1e8 — except MAYAChain's native CACAO, which it reports at its
+  // native 1e10. Amounts from these two cases are taken verbatim from mainnet actions
+  // 8F9B6692…30D (CACAO -> ETH.USDT) and DA174E41…A57 (BTC.BTC -> CACAO).
+  const cacaoAsset = {
+    symbol: 'CACAO',
+    assetId: 'cosmos:mayachain-mainnet-v1/slip44:931',
+    chainId: 'cosmos:mayachain-mainnet-v1',
+    precision: 10,
+  }
+
+  it('does not shift the sell amount when the sell leg is native CACAO', async () => {
+    const response = structuredClone(mayachainResponse)
+    response.actions[0].in[0].coins[0] = { amount: '241570000000000', asset: 'MAYA.CACAO' }
+
+    service = new SwapVerificationService(makeHttpMock(response))
+
+    const result = await service.verifySwap({ ...swap, sellAsset: cacaoAsset } as Swap)
+
+    expect(result.verifiedSellAmountCryptoBaseUnit).toBe('241570000000000')
+  })
+
+  it('does not shift the buy amount when the buy leg is native CACAO', async () => {
+    const response = structuredClone(mayachainResponse)
+    const buyOut = response.actions[0].out.find((out) => !('affiliate' in out && out.affiliate))
+    buyOut.coins[0] = { amount: '84513804751580', asset: 'MAYA.CACAO' }
+
+    service = new SwapVerificationService(makeHttpMock(response))
+
+    const result = await service.verifySwap({ ...swap, buyAsset: cacaoAsset } as Swap)
+
+    expect(result.actualBuyAmountCryptoBaseUnit).toBe('84513804751580')
+  })
+
   it('strips 0x prefix from sellTxHash before calling Midgard', async () => {
     const get = jest.fn<unknown, [string]>().mockReturnValue(of({ data: mayachainResponse }))
     service = new SwapVerificationService({ get } as unknown as HttpService)

--- a/apps/swap-service/src/verification/swap-verification.service.ts
+++ b/apps/swap-service/src/verification/swap-verification.service.ts
@@ -31,7 +31,7 @@ import {
   ZrxApiResponse,
   ZrxTrade,
 } from './types'
-import { applyBps, noAffiliateResult, thorchainToNativePrecision } from './utils'
+import { applyBps, midgardToNativePrecision, noAffiliateResult } from './utils'
 
 @Injectable()
 export class SwapVerificationService {
@@ -384,11 +384,8 @@ export class SwapVerificationService {
       hasAffiliate,
       affiliateBps: hasAffiliate ? parseInt(swapMetadata.affiliateFee) : undefined,
       affiliateAddress: hasAffiliate ? affiliateAddress : undefined,
-      verifiedSellAmountCryptoBaseUnit: thorchainToNativePrecision(
-        action.in[0].coins[0].amount,
-        swap.sellAsset.precision,
-      ),
-      actualBuyAmountCryptoBaseUnit: thorchainToNativePrecision(buyOut.coins[0].amount, swap.buyAsset.precision),
+      verifiedSellAmountCryptoBaseUnit: midgardToNativePrecision(action.in[0].coins[0], swap.sellAsset.precision),
+      actualBuyAmountCryptoBaseUnit: midgardToNativePrecision(buyOut.coins[0], swap.buyAsset.precision),
       actualAffiliateFeeAmountCryptoBaseUnit: hasAffiliate ? (feeOut?.coins[0]?.amount ?? '0') : undefined,
     }
   }

--- a/apps/swap-service/src/verification/utils.ts
+++ b/apps/swap-service/src/verification/utils.ts
@@ -1,12 +1,18 @@
 import type { SwapVerificationResult } from '@shapeshift/shared-types'
 import { bnOrZero } from '@shapeshiftoss/chain-adapters'
 
-export const BPS_DENOMINATOR = 10000n
-export const THORCHAIN_PRECISION = 8
+import type { MidgardCoin } from './types'
 
-export const thorchainToNativePrecision = (thorchainAmount: string, nativePrecision: number): string =>
-  bnOrZero(thorchainAmount)
-    .shiftedBy(nativePrecision - THORCHAIN_PRECISION)
+export const BPS_DENOMINATOR = 10000n
+export const MIDGARD_PRECISION = 8
+
+// Midgard normalizes every coin to 1e8 — except MAYAChain's native CACAO, which it reports at its
+// own 1e10 precision. Shifting CACAO by (precision - 8) like everything else inflates it 100x.
+const MIDGARD_NATIVE_PRECISION_ASSETS: Record<string, number> = { 'MAYA.CACAO': 10 }
+
+export const midgardToNativePrecision = (coin: MidgardCoin, nativePrecision: number): string =>
+  bnOrZero(coin.amount)
+    .shiftedBy(nativePrecision - (MIDGARD_NATIVE_PRECISION_ASSETS[coin.asset.toUpperCase()] ?? MIDGARD_PRECISION))
     .toFixed(0, 1)
 
 export const noAffiliateResult = (


### PR DESCRIPTION
## Description

Follow-up to #53. That PR established that MAYAChain Midgard reports native **CACAO** in **1e10**, unlike pool/external assets normalized to 1e8 ([Maya docs](https://docs.mayaprotocol.com/mayachain-dev-docs/concepts/memo-length-reduction): _"CACAO is the only asset which is expressed in 1e10 format"_), and corrected the affiliate `feeOut` amount to be stored raw.

The same assumption was still live on the other two amounts in `verifyMidgardSwap`. `thorchainToNativePrecision` shifts by `(nativePrecision - 8)`, so a CACAO **sell** leg inflated `verifiedSellAmountCryptoBaseUnit` 100×, and a CACAO **buy** leg did the same to `actualBuyAmountCryptoBaseUnit`. The sell leg feeds `volumeUsd` and the bps-implied fee in `calculateFeeForSwap`, so affiliate volume for any CACAO-sell swap was overstated 100×.

#53 reasoned that the affiliate fee is always the chain's native asset, which happens to be true but is incidental — the docs claim is broader: CACAO is 1e10 wherever it appears. `midgardToNativePrecision` therefore keys on the coin's asset rather than on which field it is, skipping the shift for `MAYA.CACAO` only.

- Non-native Maya assets unaffected — ETH at 1e8 → 1e18 still shifts.
- THORChain unaffected — RUNE native precision is 8, as #53 noted.
- `THORCHAIN_PRECISION` → `MIDGARD_PRECISION`, since it describes Midgard's normalization rather than THORChain's. Internal, no other callers.

## Testing

`yarn test` — 64/64 pass.

Two new cases in `mayachain.test.ts`, one per leg, using amounts taken verbatim from mainnet actions `8F9B6692…530D` (CACAO → ETH.USDT) and `DA174E41…A57` (BTC → CACAO). Both failed at exactly 100× before the change (`24157000000000000` vs `241570000000000`) and pass after.

Confirmed independently of #53's evidence:

- For `8F9B6692…530D` the swap's two sides only balance under the 1e10 reading — $4,616 in against $4,571 out, ~1% to fees, versus $461,641 in under the old conversion.
- Two further mainnet actions with BTC (a known-1e8 asset) on the in-side imply CACAO prices of $0.133 and $0.103 under 1e10, tracking Midgard's own reported price, versus $0.0013 and $0.0010 under 1e8.
- `revenue-dashboard`'s Maya tracker divides CACAO by 1e10 in a separate codebase.

Checked for double-correction: no consumer of `verifiedSellAmountCryptoBaseUnit` or `actualBuyAmountCryptoBaseUnit` compensates for the inflation — including `calculatePartnerFeeAmountUsd` in public-api, which derives volume from the buy side.

## Note for whoever deploys

This is forward-only and does not touch existing data. `getPendingVerificationSwaps` requires `verificationStatus: PENDING` **and** `status IN (SUCCESS, FAILED)`; no row in prod currently matches, so nothing is re-verified on deploy. Stored values stay as they are, payout script output is unchanged, and dashboard figures do not move.

For context rather than as a blocker: all 270 CACAO-leg rows currently in prod belong to a single partner code under investigation for forged attribution, and 188 of them are held back by the payout script's deviation guard purely because this bug made implied and actual fees diverge 99%. If a re-verification backfill is run later, most of those stop being anomalies — re-running `aggregateByPartner` with corrected values gives anomalies 188 → 48 and that partner's payable total $107,614.65 → $110,159.91. That is a reason to quarantine those rows before any backfill, not before this merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved swap verification for MAYAChain assets.
  * Preserved native CACAO amount precision during sell and buy verification.
  * Standardized amount conversion across supported verification flows to prevent decimal shifting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->